### PR TITLE
refactor!: implement `Field` as lazy data structure with internal cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     alias(libs.plugins.gitSemVer)
     alias(libs.plugins.taskTree)
     alias(libs.plugins.kover)
+    alias(libs.plugins.kotest)
     id("it.unibo.collektive.collektive-plugin")
 }
 
@@ -41,6 +42,7 @@ allprojects {
         apply(plugin = gitSemVer.id)
         apply(plugin = taskTree.id)
         apply(plugin = kover.id)
+        apply(plugin = kotest.id)
     }
     apply(plugin = "it.unibo.collektive.collektive-plugin")
 

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/AggregateOps.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/AggregateOps.kt
@@ -21,7 +21,7 @@ import it.unibo.collektive.field.Field
  * In this case, the field returned has the result of the computation as local value.
  */
 fun <Return> AggregateContext.neighbouring(type: Return): Field<Return> {
-    val body: (Field<Return>) -> Field<Return> = { f -> f.mapField { _, x -> x } }
+    val body: (Field<Return>) -> Field<Return> = { f -> f.map { _, x -> x } }
     return exchange(type, body)
 }
 
@@ -56,7 +56,7 @@ fun <Initial, Return> AggregateContext.sharing(
     val context = SharingContext<Initial, Return>()
     var res: Option<SharingResult<Initial, Return>> = none()
     exchange(initial) {
-        it.mapField { _, _ -> transform(context, it).also { r -> res = r.some() }.toSend }
+        it.map { _, _ -> transform(context, it).also { r -> res = r.some() }.toSend }
     }
     return res.getOrElse { error("This error should never be thrown") }.toReturn
 }

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/AggregateOps.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/AggregateOps.kt
@@ -21,7 +21,7 @@ import it.unibo.collektive.field.Field
  * In this case, the field returned has the result of the computation as local value.
  */
 fun <Return> AggregateContext.neighbouring(type: Return): Field<Return> {
-    val body: (Field<Return>) -> Field<Return> = { f -> f.map { _, x -> x } }
+    val body: (Field<Return>) -> Field<Return> = { f -> f.mapWithId { _, x -> x } }
     return exchange(type, body)
 }
 
@@ -56,7 +56,7 @@ fun <Initial, Return> AggregateContext.sharing(
     val context = SharingContext<Initial, Return>()
     var res: Option<SharingResult<Initial, Return>> = none()
     exchange(initial) {
-        it.map { _, _ -> transform(context, it).also { r -> res = r.some() }.toSend }
+        it.mapWithId { _, _ -> transform(context, it).also { r -> res = r.some() }.toSend }
     }
     return res.getOrElse { error("This error should never be thrown") }.toReturn
 }

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
@@ -99,7 +99,7 @@ internal data class ArrayBasedField<T>(
 
     override fun <B> mapWithId(transform: (ID, T) -> B): Field<B> {
         val mappedValues = others.map { (id, value) -> id to transform(id, value) }
-        return ArrayBasedField(localId, transform(localId, localValue), mappedValues)
+        return SequenceBasedField(localId, transform(localId, localValue), mappedValues.asSequence())
     }
 }
 

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
@@ -6,7 +6,7 @@ import it.unibo.collektive.ID
  * A field is a map of messages where the key is the [ID] of a node and [T] the associated value.
  * @param T the type of the field.
  */
-interface Field<out T> : Map<ID, T> {
+interface Field<out T> {
     /**
      * The [ID] of the local node.
      */
@@ -15,42 +15,99 @@ interface Field<out T> : Map<ID, T> {
     /**
      * The value associated with the [localId].
      */
-    val local: T?
+    val localValue: T
 
     /**
      * Exclude the local node from the field.
      */
-    fun excludeSelf(): Field<T> = Field(localId, filter { it.key != localId })
+    fun excludeSelf(): Map<ID, T>
 
     /**
      * Function for generic manipulation of the field.
      */
-    fun <B> mapField(transform: (ID, T) -> B): Field<B> = Field(
-        localId,
-        mapValues { (id, value) -> transform(id, value) },
-    )
+    fun <B> map(transform: (ID, T) -> B): Field<B>
+
+    /**
+     * Get the value associated with the [id].
+     * Raise an error if the [id] is not present in the field.
+     */
+    operator fun get(id: ID): T
 
     /**
      * Transform the field into a map.
      */
-    fun toMap(): Map<ID, T> = this
+    fun asSequence(): Sequence<Pair<ID, T>>
+
+    /**
+     * Returns a map repesenting the field.
+     */
+    fun toMap(): Map<ID, T>
 
     companion object {
         /**
-         * Build a field from a [localId] and a map of messages.
+         * Build a field from a [localId] and a list of messages.
          */
-        operator fun <T> invoke(localId: ID, messages: Map<ID, T> = emptyMap()): Field<T> = FieldImpl(localId, messages)
+        internal operator fun <T> invoke(
+            localId: ID,
+            localValue: T,
+            others: List<Pair<ID, T>> = emptyList(),
+        ): Field<T> = FieldImpl(localId, localValue, others)
+
+        /**
+         * Build a field from a [localId], [localValue] and [others] neighbours values.
+         */
+        internal operator fun <T> invoke(localId: ID, localValue: T, others: Map<ID, T> = emptyMap()): Field<T> =
+            FieldImpl(localId, localValue, others.map { it.toPair() })
+
+        /**
+         * Reduce the elements of the field using the [transform] function.
+         */
+        fun <T> Field<T>.reduce(transform: (accumulator: T, T) -> T): T =
+            excludeSelf().values.reduce(transform)
+
+        /**
+         * Reduce the elements of a field starting with a [initial] value and a [transform] function.
+         */
+        fun <T> Field<T>.hoodInto(initial: T = localValue, transform: (T, T) -> T): T {
+            var accumulator = initial
+            for ((_, value) in excludeSelf()) {
+                accumulator = transform(accumulator, value)
+            }
+            return accumulator
+        }
+
+        /**
+         * Reduce the elements of a field starting with a [initial] value and a [transform] function.
+         */
+        fun <T, R> Field<T>.hood(initial: R, transform: (R, T) -> R): R {
+            var accumulator = initial
+            for ((_, value) in asSequence()) {
+                accumulator = transform(accumulator, value)
+            }
+            return accumulator
+        }
     }
 }
 
-/**
- * Transform a map into a field with a [localId].
- */
-fun <T> Map<ID, T>.toField(localId: ID): Field<T> = Field(localId, this)
-
 internal data class FieldImpl<T>(
     override val localId: ID,
-    private val messages: Map<ID, T>,
-) : Field<T>, Map<ID, T> by messages {
-    override val local: T? = this[localId]
+    override val localValue: T,
+    private val others: List<Pair<ID, T>>,
+) : Field<T> {
+    private val otherClosedToMap by lazy { others.toMap() }
+
+    override fun excludeSelf(): Map<ID, T> = others.toMap()
+    override fun get(id: ID): T {
+        return if (id == localId) localValue else otherClosedToMap[id] ?: error("Field not aligned")
+    }
+
+    override fun toMap(): Map<ID, T> = otherClosedToMap + (localId to localValue)
+
+    override fun asSequence(): Sequence<Pair<ID, T>> = others.asSequence() + (localId to localValue)
+
+    override fun <B> map(transform: (ID, T) -> B): Field<B> {
+        val mappedValues = others.map { (id, value) -> id to transform(id, value) }
+        val mappedLocalValue = transform(localId, localValue)
+        return FieldImpl(localId, mappedLocalValue, mappedValues)
+    }
 }

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
@@ -1,7 +1,6 @@
 package it.unibo.collektive.field
 
 import it.unibo.collektive.ID
-import it.unibo.collektive.field.Field.Companion.isEqualTo
 
 /**
  * A field is a map of messages where the key is the [ID] of a node and [T] the associated value.
@@ -81,12 +80,6 @@ sealed interface Field<out T> {
          * Reduce the elements of a field using the [transform] function.
          */
         fun <T> Field<T>.hood(transform: (T, T) -> T): T = hoodInto(localValue, transform)
-
-        internal fun Field<*>.isEqualTo(other: Any?): Boolean = when (other) {
-            this -> true
-            is Field<*> -> toMap() == other.toMap()
-            else -> false
-        }
     }
 }
 
@@ -102,7 +95,13 @@ internal abstract class AbstractField<T>(
 
     final override fun excludeSelf(): Map<ID, T> = neighborhood
 
-    final override fun equals(other: Any?): Boolean = isEqualTo(other)
+    final override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return when (other) {
+            is Field<*> -> toMap() == other.toMap()
+            else -> false
+        }
+    }
 
     final override fun hashCode(): Int = toMap().hashCode()
 

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
@@ -44,14 +44,6 @@ interface Field<out T> {
     fun toMap(): Map<ID, T>
 
     companion object {
-        /**
-         * Build a field from a [localId] and a list of messages.
-         */
-        internal operator fun <T> invoke(
-            localId: ID,
-            localValue: T,
-            others: List<Pair<ID, T>> = emptyList(),
-        ): Field<T> = FieldImpl(localId, localValue, others)
 
         /**
          * Build a field from a [localId], [localValue] and [others] neighbours values.

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
@@ -8,7 +8,7 @@ import it.unibo.collektive.field.Field.Companion.reduce
  * @param includingSelf if true the local node is included in the computation.
  */
 fun <T : Comparable<T>> Field<T>.min(includingSelf: Boolean = true): T = when (includingSelf) {
-    true -> hood(localValue) { acc, value -> if (value < acc) value else acc }
+    true -> hood { acc, value -> if (value < acc) value else acc }
     false -> reduce { acc, value -> if (value < acc) value else acc }
 }
 
@@ -17,19 +17,19 @@ fun <T : Comparable<T>> Field<T>.min(includingSelf: Boolean = true): T = when (i
  * @param includingSelf if true the local node is included in the computation.
  */
 fun <T : Comparable<T>> Field<T>.max(includingSelf: Boolean = true): T = when (includingSelf) {
-    true -> hood(localValue) { acc, value -> if (value > acc) value else acc }
+    true -> hood { acc, value -> if (value > acc) value else acc }
     false -> reduce { acc, value -> if (value > acc) value else acc }
 }
 
 /**
  * Operator to sum a [value] to all the values of the field.
  */
-operator fun <T : Number> Field<T>.plus(value: T): Field<T> = map { _, oldValue -> add(oldValue, value) }
+operator fun <T : Number> Field<T>.plus(value: T): Field<T> = mapWithId { _, oldValue -> add(oldValue, value) }
 
 /**
  * Operator to subtract a [value] to all the values of the field.
  */
-operator fun <T : Number> Field<T>.minus(value: T): Field<T> = map { _, oldValue -> sub(oldValue, value) }
+operator fun <T : Number> Field<T>.minus(value: T): Field<T> = mapWithId { _, oldValue -> sub(oldValue, value) }
 
 /**
  * Sum a field with [other] field.
@@ -48,7 +48,7 @@ operator fun <T : Number> Field<T>.minus(other: Field<T>): Field<T> = combine(th
  * The two fields must be aligned, otherwise an error is thrown.
  */
 fun <T, V, R> combine(field1: Field<T>, field: Field<V>, transform: (T, V) -> R): Field<R> {
-    return field1.map { id, value -> transform(value, field[id] ?: error("Field not aligned")) }
+    return field1.mapWithId { id, value -> transform(value, field[id] ?: error("Field not aligned")) }
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
@@ -9,7 +9,7 @@ import it.unibo.collektive.field.Field.Companion.reduce
  */
 fun <T : Comparable<T>> Field<T>.min(includingSelf: Boolean = true): T = when (includingSelf) {
     true -> hood { acc, value -> if (value < acc) value else acc }
-    false -> reduce { acc, value -> if (value < acc) value else acc }
+    false -> reduce(includingSelf = false) { acc, value -> if (value < acc) value else acc }
 }
 
 /**
@@ -18,7 +18,7 @@ fun <T : Comparable<T>> Field<T>.min(includingSelf: Boolean = true): T = when (i
  */
 fun <T : Comparable<T>> Field<T>.max(includingSelf: Boolean = true): T = when (includingSelf) {
     true -> hood { acc, value -> if (value > acc) value else acc }
-    false -> reduce { acc, value -> if (value > acc) value else acc }
+    false -> reduce(includingSelf = false) { acc, value -> if (value > acc) value else acc }
 }
 
 /**

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/ExchangeTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/ExchangeTest.kt
@@ -33,14 +33,14 @@ class ExchangeTest : StringSpec({
     val path2 = Path(listOf("exchange.2"))
 
     val increaseOrDouble: (Field<Int>) -> Field<Int> = { f ->
-        f.mapField { _, v -> if (v % 2 == 0) v + 1 else v * 2 }
+        f.map { _, v -> if (v % 2 == 0) v + 1 else v * 2 }
     }
 
     "First time exchange should return the initial value" {
         aggregate(id0) {
             val res = exchange(initV1, increaseOrDouble)
-            res shouldBe Field(id0, mapOf(id0 to 2))
-            messagesToSend() shouldBe setOf(IsotropicMessage(id0, mapOf(path1 to res.local)) as OutboundMessage)
+            res shouldBe Field(id0, 2)
+            messagesToSend() shouldBe setOf(IsotropicMessage(id0, mapOf(path1 to res.localValue)) as OutboundMessage)
         }
     }
 
@@ -55,11 +55,11 @@ class ExchangeTest : StringSpec({
             val res1 = exchange(initV1, increaseOrDouble)
             val res2 = exchange(initV2, increaseOrDouble)
             testNetwork1.read() shouldHaveSize 0
-            res1 shouldBe Field(id1, mapOf(id1 to 2))
-            res2 shouldBe Field(id1, mapOf(id1 to 3))
+            res1 shouldBe Field(id1, 2)
+            res2 shouldBe Field(id1, 3)
             messagesToSend() shouldBe setOf(
-                IsotropicMessage(id1, mapOf(path1 to res1.local)),
-                IsotropicMessage(id1, mapOf(path2 to res2.local)),
+                IsotropicMessage(id1, mapOf(path1 to res1.localValue)),
+                IsotropicMessage(id1, mapOf(path2 to res2.localValue)),
             )
         }
 
@@ -70,8 +70,8 @@ class ExchangeTest : StringSpec({
             val res1 = exchange(initV3, increaseOrDouble)
             val res2 = exchange(initV4, increaseOrDouble)
             testNetwork2.read() shouldHaveSize 2
-            res1 shouldBe Field(id2, mapOf(id1 to 3, id2 to 6))
-            res2 shouldBe Field(id2, mapOf(id1 to 6, id2 to 5))
+            res1 shouldBe Field(id2, 6, mapOf(id1 to 3))
+            res2 shouldBe Field(id2, 5, mapOf(id1 to 6))
             messagesToSend() shouldBe setOf(
                 IsotropicMessage(id2, mapOf(path1 to initV3 * 2)),
                 IsotropicMessage(id2, mapOf(path2 to initV4 + 1)),
@@ -86,8 +86,8 @@ class ExchangeTest : StringSpec({
             val res1 = exchange(initV5, increaseOrDouble)
             val res2 = exchange(initV6, increaseOrDouble)
             testNetwork3.read() shouldHaveSize 4
-            res1 shouldBe Field(id3, mapOf(id1 to 3, id2 to 7, id3 to 10))
-            res2 shouldBe Field(id3, mapOf(id1 to 6, id2 to 10, id3 to 7))
+            res1 shouldBe Field(id3, 10, mapOf(id1 to 3, id2 to 7))
+            res2 shouldBe Field(id3, 7, mapOf(id1 to 6, id2 to 10))
             messagesToSend() shouldBe setOf(
                 IsotropicMessage(id3, mapOf(path1 to initV5 * 2)),
                 IsotropicMessage(id3, mapOf(path2 to initV6 + 1)),

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/ExchangeTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/ExchangeTest.kt
@@ -39,7 +39,7 @@ class ExchangeTest : StringSpec({
     "First time exchange should return the initial value" {
         aggregate(id0) {
             val res = exchange(initV1, increaseOrDouble)
-            res shouldBe Field(id0, 2)
+            res[id0] shouldBe 2
             messagesToSend() shouldBe setOf(IsotropicMessage(id0, mapOf(path1 to res.localValue)) as OutboundMessage)
         }
     }
@@ -55,8 +55,8 @@ class ExchangeTest : StringSpec({
             val res1 = exchange(initV1, increaseOrDouble)
             val res2 = exchange(initV2, increaseOrDouble)
             testNetwork1.read() shouldHaveSize 0
-            res1 shouldBe Field(id1, 2)
-            res2 shouldBe Field(id1, 3)
+            res1[id1] shouldBe 2
+            res2[id1] shouldBe 3
             messagesToSend() shouldBe setOf(
                 IsotropicMessage(id1, mapOf(path1 to res1.localValue)),
                 IsotropicMessage(id1, mapOf(path2 to res2.localValue)),
@@ -70,8 +70,8 @@ class ExchangeTest : StringSpec({
             val res1 = exchange(initV3, increaseOrDouble)
             val res2 = exchange(initV4, increaseOrDouble)
             testNetwork2.read() shouldHaveSize 2
-            res1 shouldBe Field(id2, 6, mapOf(id1 to 3))
-            res2 shouldBe Field(id2, 5, mapOf(id1 to 6))
+            res1.toMap() shouldBe mapOf(id2 to 6, id1 to 3)
+            res2.toMap() shouldBe mapOf(id2 to 5, id1 to 6)
             messagesToSend() shouldBe setOf(
                 IsotropicMessage(id2, mapOf(path1 to initV3 * 2)),
                 IsotropicMessage(id2, mapOf(path2 to initV4 + 1)),
@@ -86,8 +86,8 @@ class ExchangeTest : StringSpec({
             val res1 = exchange(initV5, increaseOrDouble)
             val res2 = exchange(initV6, increaseOrDouble)
             testNetwork3.read() shouldHaveSize 4
-            res1 shouldBe Field(id3, 10, mapOf(id1 to 3, id2 to 7))
-            res2 shouldBe Field(id3, 7, mapOf(id1 to 6, id2 to 10))
+            res1.toMap() shouldBe mapOf(id3 to 10, id1 to 3, id2 to 7)
+            res2.toMap() shouldBe mapOf(id3 to 7, id1 to 6, id2 to 10)
             messagesToSend() shouldBe setOf(
                 IsotropicMessage(id3, mapOf(path1 to initV5 * 2)),
                 IsotropicMessage(id3, mapOf(path2 to initV6 + 1)),

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/ExchangeTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/ExchangeTest.kt
@@ -33,7 +33,7 @@ class ExchangeTest : StringSpec({
     val path2 = Path(listOf("exchange.2"))
 
     val increaseOrDouble: (Field<Int>) -> Field<Int> = { f ->
-        f.map { _, v -> if (v % 2 == 0) v + 1 else v * 2 }
+        f.mapWithId { _, v -> if (v % 2 == 0) v + 1 else v * 2 }
     }
 
     "First time exchange should return the initial value" {

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/RepeatingTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/RepeatingTest.kt
@@ -42,7 +42,7 @@ class RepeatingTest : StringSpec({
                 neighbouring(it * 2)
             }
         }
-        result.result.local shouldBe initV1 * 2
+        result.result.localValue shouldBe initV1 * 2
         result.toSend.firstOrNull()?.getPaths()?.shouldContain(
             Path(listOf("repeating.1", "neighbouring.1", "exchange.1")),
         )

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/SharingTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/SharingTest.kt
@@ -6,6 +6,8 @@ import it.unibo.collektive.IntId
 import it.unibo.collektive.aggregate.ops.share
 import it.unibo.collektive.aggregate.ops.sharing
 import it.unibo.collektive.field.Field
+import it.unibo.collektive.field.max
+import it.unibo.collektive.field.min
 import it.unibo.collektive.network.NetworkImplTest
 import it.unibo.collektive.network.NetworkManager
 
@@ -25,7 +27,7 @@ class SharingTest : StringSpec({
     val initV7 = 7
     val initV10 = 10
 
-    val findMax: (Field<Int>) -> Int = { e -> e.maxBy { it.value }.value }
+    val findMax: (Field<Int>) -> Int = { e -> e.max() }
 
     "first time sharing" {
         aggregate(id0) {
@@ -83,7 +85,7 @@ class SharingTest : StringSpec({
 
         aggregate(id1, condition, testNetwork1) {
             val res = share(initV1) {
-                it.maxBy { v -> v.value }.value
+                it.max()
             }
             res shouldBe initV1
         }
@@ -97,7 +99,7 @@ class SharingTest : StringSpec({
 
         aggregate(id1, condition, testNetwork1) {
             val res = sharing(initV1) {
-                val min = it.maxBy { v -> v.value }.value
+                val min = it.max()
                 min.yielding { "A string" }
             }
             res shouldBe "A string"
@@ -112,7 +114,7 @@ class SharingTest : StringSpec({
 
         aggregate(id1, condition, testNetwork1) {
             val res = sharing(initV1) {
-                val min = it.minBy { v -> v.value }.value
+                val min = it.min()
                 min.yielding { "Hello".takeIf { min > 1 } }
             }
             res shouldBe null

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/TestAlignment.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/TestAlignment.kt
@@ -16,7 +16,7 @@ class TestAlignment : StringSpec({
             val result = aggregate(IntId(0)) {
                 neighbouring(10) // path -> [neighbouring.1] = 10
                 share(0) {
-                    requireNotNull(neighbouring(20).local) // path -> [share.1, neighbouring.2] = 20
+                    requireNotNull(neighbouring(20).localValue) // path -> [share.1, neighbouring.2] = 20
                 } // path -> [sharing.1] = Field(...)
                 neighbouring(30) // path -> [neighbouring.3] = 30
                 5

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldManipulationTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldManipulationTest.kt
@@ -10,7 +10,7 @@ import it.unibo.collektive.network.NetworkImplTest
 import it.unibo.collektive.network.NetworkManager
 
 class FieldManipulationTest : StringSpec({
-    var nm = NetworkManager()
+    val nm = NetworkManager()
     val double: (Int) -> Int = { it * 2 }
     var i = 0
     val condition: () -> Boolean = { i++ < 1 }

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldManipulationTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldManipulationTest.kt
@@ -31,7 +31,7 @@ class FieldManipulationTest : StringSpec({
         aggregate(id1, condition, network1) {
             val res = neighbouring(double(2)).min()
             res shouldNotBe null
-            if (res != null) res.value shouldBe 4
+            res shouldBe 4
         }
     }
 
@@ -48,7 +48,7 @@ class FieldManipulationTest : StringSpec({
         aggregate(id1, condition, network1) {
             val res = neighbouring(double(2)).min(includingSelf = false)
             res shouldNotBe null
-            if (res != null) res.value shouldBe 6
+            res shouldBe 6
         }
     }
 
@@ -65,7 +65,7 @@ class FieldManipulationTest : StringSpec({
         aggregate(id1, condition, network1) {
             val res = neighbouring(double(2)).max(includingSelf = false)
             res shouldNotBe null
-            if (res != null) res.value shouldBe 6
+            res shouldBe 6
         }
     }
 })

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
@@ -2,9 +2,7 @@ package it.unibo.collektive.field
 
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
-import io.kotest.matchers.collections.shouldContainAnyOf
 import io.kotest.matchers.equals.shouldNotBeEqual
 import io.kotest.matchers.shouldBe
 import it.unibo.collektive.IntId

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
@@ -1,0 +1,15 @@
+package it.unibo.collektive.field
+
+import io.kotest.assertions.throwables.shouldThrowUnit
+import io.kotest.core.spec.style.StringSpec
+import it.unibo.collektive.IntId
+import it.unibo.collektive.field.Field.Companion.reduce
+
+class FieldOpsTest : StringSpec({
+    "An empty field should raise an exception when is reduced" {
+        val field = Field(IntId(0), 0)
+        shouldThrowUnit<UnsupportedOperationException> {
+            field.reduce(includingSelf = false) { acc, elem -> acc + elem }
+        }
+    }
+})

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
@@ -2,14 +2,62 @@ package it.unibo.collektive.field
 
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainAnyOf
+import io.kotest.matchers.equals.shouldNotBeEqual
+import io.kotest.matchers.shouldBe
 import it.unibo.collektive.IntId
+import it.unibo.collektive.field.Field.Companion.hood
+import it.unibo.collektive.field.Field.Companion.hoodInto
 import it.unibo.collektive.field.Field.Companion.reduce
 
 class FieldOpsTest : StringSpec({
+    val emptyField = Field(IntId(0), "localVal")
+    val fulfilledField = Field(IntId(0), 0, mapOf(IntId(1) to 10, IntId(2) to 20))
+
     "An empty field should raise an exception when is reduced" {
-        val field = Field(IntId(0), 0)
         shouldThrowUnit<UnsupportedOperationException> {
-            field.reduce(includingSelf = false) { acc, elem -> acc + elem }
+            emptyField.reduce(includingSelf = false) { acc, elem -> acc + elem }
         }
+    }
+    "An empty field should return the self value value when is hooded" {
+        emptyField.hood { acc, elem -> acc + elem } shouldBe "localVal"
+    }
+    "An empty field should return the initial value when is hooded excluding self" {
+        emptyField.hoodInto("initial") { acc, elem -> acc + elem } shouldBe "initial"
+    }
+    "An empty field when mapped only the local value should be transformed" {
+        emptyField.map { "$it-mapped" } shouldBe Field(IntId(0), "localVal-mapped", mapOf())
+    }
+    "A field can be mapped on its values with a given function" {
+        fulfilledField.map { it + 3 } shouldBe Field(
+            IntId(0),
+            3,
+            mapOf(IntId(1) to 13, IntId(2) to 23),
+        )
+    }
+    "A field can be mapped on its values with a given function and the id" {
+        fulfilledField.mapWithId { id, value -> "${(id as IntId).id}-$value" } shouldBe Field(
+            IntId(0),
+            "0-0",
+            mapOf(IntId(1) to "1-10", IntId(2) to "2-20"),
+        )
+    }
+    "Two fields are equals if they are the same instance" {
+        fulfilledField shouldBe fulfilledField
+    }
+    "Two field are equals if they contains the same values" {
+        fulfilledField shouldBe Field(IntId(0), 0, mapOf(IntId(1) to 10, IntId(2) to 20))
+    }
+    "Two fields are not equals if they contains different values" {
+        fulfilledField shouldNotBeEqual Field(IntId(0), 0, mapOf(IntId(1) to -1, IntId(2) to -1))
+    }
+    "Two field are not equals if the contains the same neighbouring values but the local id is different" {
+        fulfilledField shouldNotBeEqual Field(IntId(10), 0, mapOf(IntId(1) to 10, IntId(2) to 20))
+    }
+    "A field should return a sequence containing all the values" {
+        fulfilledField.asSequence().toList() shouldContainAll
+            sequenceOf(IntId(0) to 0, IntId(1) to 10, IntId(2) to 20).toList()
     }
 })

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldTest.kt
@@ -14,14 +14,14 @@ class FieldTest {
 
     @Test
     fun createFieldWithoutMessages() {
-        val field: Field<String> = Field(myId, mapOf(myId to myValue))
+        val field: Field<String> = Field(myId, myValue)
         assertTrue(field.toMap().containsKey(myId))
         assertEquals(1, field.toMap().size)
     }
 
     @Test
     fun createFieldWithMessages() {
-        val field: Field<String> = Field(myId, mapOf(connectedId to connectedValue, myId to myValue))
+        val field: Field<String> = Field(myId, myValue, mapOf(connectedId to connectedValue))
         assertTrue(field.toMap().containsKey(myId))
         assertTrue(field.toMap().containsKey(connectedId))
         assertEquals(2, field.toMap().size)
@@ -29,7 +29,7 @@ class FieldTest {
 
     @Test
     fun getFieldValueById() {
-        val field: Field<String> = Field(myId, mapOf(connectedId to connectedValue, myId to myValue))
+        val field: Field<String> = Field(myId, myValue, mapOf(connectedId to connectedValue))
         assertEquals(myValue, field[myId])
         assertEquals(connectedValue, field[connectedId])
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,3 +40,4 @@ detekt = "io.gitlab.arturbosch.detekt:1.23.3"
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-config" }
 gradlePluginPublish = { id = "com.gradle.plugin-publish", version = "1.2.1" }
 kover = "org.jetbrains.kotlinx.kover:0.7.4"
+kotest = { id = "io.kotest.multiplatform", version.ref = "kotest" }


### PR DESCRIPTION
Refactor of the `Field` implementation via lazy data structure to efficiently apply transform operation over them.
The `Field` interface is now `sealed` and the only way to create a field is via the `exchange`
