### PR TITLE
fix!: implement rule `[E-FLD]` as described in https://doi.org/10.1145/3285956. Fixes #171

### DIFF
--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/AggregateContext.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/AggregateContext.kt
@@ -70,7 +70,7 @@ class AggregateContext(
             val path = stack.currentPath()
             check(!toBeSent.messages.containsKey(path)) {
                 "Alignment was broken by multiple aligned calls with the same path: $path. " +
-                    "The most likely cause is an aggregate function call within a loop"
+                        "The most likely cause is an aggregate function call within a loop"
             }
             toBeSent = toBeSent.copy(messages = toBeSent.messages + (stack.currentPath() to message))
             state = state + (stack.currentPath() to field.localValue)
@@ -101,11 +101,10 @@ class AggregateContext(
     fun <Initial> repeat(
         initial: Initial,
         transform: (Initial) -> Initial,
-    ): Initial =
-        repeating(initial) {
-            val res = transform(it)
-            RepeatingResult(res, res)
-        }
+    ): Initial = repeating(initial) {
+        val res = transform(it)
+        RepeatingResult(res, res)
+    }
 
     /**
      * Alignment function that pushes in the stack the pivot, executes the body and pop the last

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/AggregateContext.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/AggregateContext.kt
@@ -70,7 +70,7 @@ class AggregateContext(
             val path = stack.currentPath()
             check(!toBeSent.messages.containsKey(path)) {
                 "Alignment was broken by multiple aligned calls with the same path: $path. " +
-                        "The most likely cause is an aggregate function call within a loop"
+                    "The most likely cause is an aggregate function call within a loop"
             }
             toBeSent = toBeSent.copy(messages = toBeSent.messages + (stack.currentPath() to message))
             state = state + (stack.currentPath() to field.localValue)

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/AggregateContext.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/AggregateContext.kt
@@ -22,7 +22,7 @@ import it.unibo.collektive.state.getTyped
  * and the [previousState] of the device.
  */
 class AggregateContext(
-    private val localId: ID,
+    val localId: ID,
     private val messages: Iterable<InboundMessage>,
     private val previousState: State,
 ) {

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/ExchangeBasedOps.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/ExchangeBasedOps.kt
@@ -20,10 +20,9 @@ import it.unibo.collektive.field.Field
  * ```
  * In this case, the field returned has the result of the computation as local value.
  */
-fun <Return> AggregateContext.neighbouring(type: Return): Field<Return> {
-    val body: (Field<Return>) -> Field<Return> = { f -> f.mapWithId { _, x -> x } }
-    return exchange(type, body)
-}
+fun <Return> AggregateContext.neighbouring(type: Return): Field<Return> =
+    exchange(type) { it.mapWithId { _, x -> x } }
+
 
 /**
  * [sharing] captures the space-time nature of field computation through observation of neighbours' values, starting

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/ExchangeBasedOps.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/ExchangeBasedOps.kt
@@ -23,7 +23,6 @@ import it.unibo.collektive.field.Field
 fun <Return> AggregateContext.neighbouring(type: Return): Field<Return> =
     exchange(type) { it.mapWithId { _, x -> x } }
 
-
 /**
  * [sharing] captures the space-time nature of field computation through observation of neighbours' values, starting
  * from an [initial] value, it reduces to a single local value given a [transform] function and updating and sharing

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/ExchangeBasedOps.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/ops/ExchangeBasedOps.kt
@@ -20,8 +20,8 @@ import it.unibo.collektive.field.Field
  * ```
  * In this case, the field returned has the result of the computation as local value.
  */
-fun <Return> AggregateContext.neighbouring(type: Return): Field<Return> =
-    exchange(type) { it.mapWithId { _, x -> x } }
+fun <Scalar> AggregateContext.neighbouring(local: Scalar): Field<Scalar> =
+    exchange(local) { it.mapWithId { _, x -> x } }
 
 /**
  * [sharing] captures the space-time nature of field computation through observation of neighbours' values, starting

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
@@ -18,7 +18,7 @@ sealed interface Field<out T> {
     val localValue: T
 
     /**
-     * Returns a map with the neighboring values of this field (namely, all values but self).
+     * Returns a [Map] with the neighboring values of this field (namely, all values but self).
      */
     fun excludeSelf(): Map<ID, T>
 

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
@@ -1,8 +1,6 @@
 package it.unibo.collektive.field
 
 import it.unibo.collektive.ID
-import it.unibo.collektive.aggregate.AggregateContext
-import it.unibo.collektive.aggregate.ops.neighbouring
 
 /**
  * A field is a map of messages where the key is the [ID] of a node and [T] the associated value.
@@ -173,22 +171,4 @@ internal class SequenceBasedField<T>(
 
     override fun <R> mapOthersAsSequence(transform: (ID, T) -> R): Sequence<Pair<ID, R>> =
         others.map { (id, value) -> id to transform(id, value) }
-}
-
-/**
- * TODO.
- */
-fun <T> AggregateContext.project(field: Field<T>): Field<T> {
-    val others = neighbouring(0.toByte())
-    return when {
-        field.neighborsCount == others.neighborsCount -> field
-        field.neighborsCount > others.neighborsCount -> others.mapWithId { id, _ -> field[id] }
-        else -> error(
-            """
-                Collektive is in an inconsistent state, this is most likely a bug in the implementation.
-                Field ${field} with ${field.neighborsCount} neighbors has been projected into a context
-                with more neighbors, ${others.neighborsCount}: ${others.excludeSelf().keys}.
-                """.trimIndent().replace(Regex("'\\R"), " ")
-        )
-    }
 }

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
@@ -48,7 +48,8 @@ operator fun <T : Number> Field<T>.minus(other: Field<T>): Field<T> = combine(ot
  * The two fields must be aligned, otherwise an error is thrown.
  */
 fun <T, V, R> Field<T>.combine(otherField: Field<V>, transform: (T, V) -> R): Field<R> {
-    fun fieldAlignmentErrorMessage(): String = """
+    fun fieldAlignmentErrorMessage(): String =
+        """
             Field misalignment. This is most likely a bug in Collektive,
             please report at https://github.com/Collektive/collektive/issues/new/choose
             base field: $this

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
@@ -35,20 +35,28 @@ operator fun <T : Number> Field<T>.minus(value: T): Field<T> = mapWithId { _, ol
  * Sum a field with [other] field.
  * The two fields must be aligned, otherwise an error is thrown.
  */
-operator fun <T : Number> Field<T>.plus(other: Field<T>): Field<T> = combine(this, other) { a, b -> add(a, b) }
+operator fun <T : Number> Field<T>.plus(other: Field<T>): Field<T> = combine(other) { a, b -> add(a, b) }
 
 /**
  * Subtract a field with [other] field.
  * The two fields must be aligned, otherwise an error is thrown.
  */
-operator fun <T : Number> Field<T>.minus(other: Field<T>): Field<T> = combine(this, other) { a, b -> sub(a, b) }
+operator fun <T : Number> Field<T>.minus(other: Field<T>): Field<T> = combine(other) { a, b -> sub(a, b) }
 
 /**
  * Combine two fields with a [transform] function.
  * The two fields must be aligned, otherwise an error is thrown.
  */
-fun <T, V, R> combine(field1: Field<T>, field: Field<V>, transform: (T, V) -> R): Field<R> {
-    return field1.mapWithId { id, value -> transform(value, field[id] ?: error("Field not aligned")) }
+fun <T, V, R> Field<T>.combine(otherField: Field<V>, transform: (T, V) -> R): Field<R> {
+    require(neighborsCount == otherField.neighborsCount) {
+        """
+            The two fields are not aligned.
+            field: $this
+            otherField: $otherField
+            The field has $neighborsCount neighbors, while the other field has ${otherField.neighborsCount} neighbors.
+        """.trimIndent()
+    }
+    return mapWithId { id, value -> transform(value, otherField[id] ?: error("Field not aligned")) }
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
@@ -50,9 +50,10 @@ operator fun <T : Number> Field<T>.minus(other: Field<T>): Field<T> = combine(ot
 fun <T, V, R> Field<T>.combine(otherField: Field<V>, transform: (T, V) -> R): Field<R> {
     require(neighborsCount == otherField.neighborsCount) {
         """
-            The two fields are not aligned.
-            field: $this
-            otherField: $otherField
+            Field misalignment. This is most likely a bug in Collektive,
+            please report at https://github.com/Collektive/collektive/issues/new/choose
+            base field: $this
+            field it has being combined with: $otherField
             The field has $neighborsCount neighbors, while the other field has ${otherField.neighborsCount} neighbors.
         """.trimIndent()
     }

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
@@ -48,8 +48,7 @@ operator fun <T : Number> Field<T>.minus(other: Field<T>): Field<T> = combine(ot
  * The two fields must be aligned, otherwise an error is thrown.
  */
 fun <T, V, R> Field<T>.combine(otherField: Field<V>, transform: (T, V) -> R): Field<R> {
-    require(neighborsCount == otherField.neighborsCount) {
-        """
+    fun fieldAlignmentErrorMessage(): String = """
             Field misalignment. This is most likely a bug in Collektive,
             please report at https://github.com/Collektive/collektive/issues/new/choose
             base field: $this
@@ -57,8 +56,8 @@ fun <T, V, R> Field<T>.combine(otherField: Field<V>, transform: (T, V) -> R): Fi
             The field has $neighborsCount neighbors, while the other field has ${otherField.neighborsCount} neighbors.
             The set of different neighbors IDs is: ${excludeSelf().keys - otherField.excludeSelf().keys}
         """.trimIndent()
-    }
-    return mapWithId { id, value -> transform(value, otherField[id] ?: error("Field not aligned")) }
+    require(neighborsCount == otherField.neighborsCount) { fieldAlignmentErrorMessage() }
+    return mapWithId { id, value -> transform(value, otherField[id] ?: error(fieldAlignmentErrorMessage())) }
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/FieldManipulation.kt
@@ -55,6 +55,7 @@ fun <T, V, R> Field<T>.combine(otherField: Field<V>, transform: (T, V) -> R): Fi
             base field: $this
             field it has being combined with: $otherField
             The field has $neighborsCount neighbors, while the other field has ${otherField.neighborsCount} neighbors.
+            The set of different neighbors IDs is: ${excludeSelf().keys - otherField.excludeSelf().keys}
         """.trimIndent()
     }
     return mapWithId { id, value -> transform(value, otherField[id] ?: error("Field not aligned")) }

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/ExchangeTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/aggregate/ExchangeTest.kt
@@ -112,12 +112,14 @@ class ExchangeTest : StringSpec({
                     path1 to SingleOutboundMessage(
                         expected10,
                         mapOf(
+                            id1 to expected3,
                             id2 to expected7,
                         ),
                     ),
                     path2 to SingleOutboundMessage(
                         expected7,
                         mapOf(
+                            id1 to expected6,
                             id2 to expected10,
                         ),
                     ),

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/BranchAlignment.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/BranchAlignment.kt
@@ -1,12 +1,20 @@
 package it.unibo.collektive.alignment
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import it.unibo.collektive.Collektive.Companion.aggregate
 import it.unibo.collektive.IntId
 import it.unibo.collektive.aggregate.ops.neighbouring
+import it.unibo.collektive.field.Field.Companion.hood
+import it.unibo.collektive.field.minus
+import it.unibo.collektive.field.plus
+import it.unibo.collektive.network.NetworkImplTest
+import it.unibo.collektive.network.NetworkManager
 import it.unibo.collektive.stack.Path
+import kotlin.random.Random
 
 class BranchAlignment : StringSpec({
     val id0 = IntId(0)
@@ -42,5 +50,24 @@ class BranchAlignment : StringSpec({
             }
         }
         result.toSend.messages.keys shouldHaveSize 0 // 0 path of alignment
+    }
+    "A field should be projected when used in a body of a branch condition (issue #171)" {
+        val nm = NetworkManager()
+        (0..3)
+            .map { IntId(it) }
+            .map { NetworkImplTest(nm, it) to it }
+            .map { (net, id) ->
+                aggregate(id, net) {
+                    val x = neighbouring(0)
+                    x.neighborsCount shouldBe id.id
+                    if (id.id % 2 == 0) {
+                        neighbouring(1).neighborsCount shouldBe id.id / 2
+                        neighbouring(1) + x
+                    } else {
+                        neighbouring(1).neighborsCount shouldBe (id.id - 1) / 2
+                        neighbouring(1) - x
+                    }
+                }
+            }
     }
 })

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/BranchAlignment.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/BranchAlignment.kt
@@ -9,6 +9,7 @@ import it.unibo.collektive.IntId
 import it.unibo.collektive.aggregate.AggregateContext
 import it.unibo.collektive.aggregate.ops.neighbouring
 import it.unibo.collektive.field.Field
+import it.unibo.collektive.field.combine
 import it.unibo.collektive.field.min
 import it.unibo.collektive.field.minus
 import it.unibo.collektive.field.plus
@@ -101,5 +102,18 @@ class BranchAlignment : StringSpec({
     }
     "A field should be projected whenever there is an alignment regardless of the type, not just booleans (issue #171)" {
         manuallyAlignedExchangeWithThreeDevices { it % 2 }
+    }
+    "A field should be projected when it is a non-direct receiver (issue #171)" {
+        exchangeWithThreeDevices {
+            with(it) {
+                with((localId as IntId).id % 2 == 0) {
+                    if (this) {
+                        combine(neighbouring(1)) { a, b -> a + b }
+                    } else {
+                        combine(neighbouring(1)) { a, b -> a - b }
+                    }
+                }
+            }
+        }
     }
 })

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/BranchAlignment.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/BranchAlignment.kt
@@ -11,6 +11,7 @@ import it.unibo.collektive.aggregate.ops.neighbouring
 import it.unibo.collektive.field.Field.Companion.hood
 import it.unibo.collektive.field.minus
 import it.unibo.collektive.field.plus
+import it.unibo.collektive.field.project
 import it.unibo.collektive.network.NetworkImplTest
 import it.unibo.collektive.network.NetworkManager
 import it.unibo.collektive.stack.Path
@@ -53,7 +54,7 @@ class BranchAlignment : StringSpec({
     }
     "A field should be projected when used in a body of a branch condition (issue #171)" {
         val nm = NetworkManager()
-        (0..3)
+        (0..2)
             .map { IntId(it) }
             .map { NetworkImplTest(nm, it) to it }
             .map { (net, id) ->

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/BranchAlignment.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/BranchAlignment.kt
@@ -100,9 +100,10 @@ class BranchAlignment : StringSpec({
     "A field should be projected whenever there is an alignment operation, not just on branches (issue #171)" {
         manuallyAlignedExchangeWithThreeDevices { it % 2 == 0 }
     }
-    "A field should be projected whenever there is an alignment regardless of the type, not just booleans (issue #171)" {
-        manuallyAlignedExchangeWithThreeDevices { it % 2 }
-    }
+    "A field should be projected whenever there is an alignment regardless of the type," +
+        " not just booleans (issue #171)" {
+            manuallyAlignedExchangeWithThreeDevices { it % 2 }
+        }
     "A field should be projected when it is a non-direct receiver (issue #171)" {
         exchangeWithThreeDevices {
             with(it) {

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/network/NetworkManager.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/network/NetworkManager.kt
@@ -15,7 +15,7 @@ class NetworkManager {
      * Adds the [message] to the message buffer.
      */
     fun send(message: OutboundMessage) {
-        messageBuffer = messageBuffer + message
+        messageBuffer = messageBuffer.filterNot { it.senderId == message.senderId }.toSet() + message
     }
 
     /**
@@ -30,30 +30,5 @@ class NetworkManager {
                     single.overrides.getOrElse(receiverId) { single.default }
                 },
             )
-        }.also {
-            remove(receiverId)
         }
-
-    private fun remove(receiverId: ID) {
-        messageBuffer = messageBuffer.mapNotNull { outbound ->
-            if (outbound.senderId != receiverId) {
-                val newOutbound = OutboundMessage(
-                    outbound.senderId,
-                    outbound.messages.mapValues { (_, message) ->
-                        SingleOutboundMessage(
-                            message.default,
-                            message.overrides.filterNot { it.key == receiverId },
-                        )
-                    },
-                )
-                if (newOutbound.messages.filterNot { it.value.overrides.isEmpty() }.isNotEmpty()) {
-                    newOutbound
-                } else {
-                    null
-                }
-            } else {
-                outbound
-            }
-        }.toSet()
-    }
 }

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/network/NetworkManager.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/network/NetworkManager.kt
@@ -3,7 +3,6 @@ package it.unibo.collektive.network
 import it.unibo.collektive.ID
 import it.unibo.collektive.networking.InboundMessage
 import it.unibo.collektive.networking.OutboundMessage
-import it.unibo.collektive.networking.SingleOutboundMessage
 
 /**
  * Implementation of the Network interface.

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/AggregateCallTransformer.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/AggregateCallTransformer.kt
@@ -2,10 +2,8 @@ package it.unibo.collektive
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrClass
-import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
@@ -26,9 +24,7 @@ class AggregateCallTransformer(
     private val aggregateContext = aggregateContextClass.thisReceiver?.type
 
     override fun visitFunction(declaration: IrFunction): IrStatement {
-        val isAggregate = generateSequence<IrElement>(declaration) { (it as? IrDeclaration)?.parent }
-            .any { declaration.extensionReceiverParameter?.type == aggregateContext }
-        if (isAggregate) {
+        if (declaration.extensionReceiverParameter?.type == aggregateContext) {
             /*
              This transformation is needed to project field inside the `alignOn` function called directly by the user.
              This is made before the alignment transformation because of optimization reasons:

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentTransformer.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentTransformer.kt
@@ -4,6 +4,7 @@ import it.unibo.collektive.utils.branch.addBranchAlignment
 import it.unibo.collektive.utils.branch.findAggregateReference
 import it.unibo.collektive.utils.call.buildAlignedOnCall
 import it.unibo.collektive.utils.common.AggregateFunctionNames.ALIGNED_ON_FUNCTION
+import it.unibo.collektive.utils.common.getFunctionName
 import it.unibo.collektive.utils.statement.irStatement
 import it.unibo.collektive.visitors.collectAggregateContextReference
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -37,11 +38,7 @@ class AlignmentTransformer(
         val contextReference = expression.receiverAndArgs().find { it.type == aggregateContextClass.defaultType }
             ?: collectAggregateContextReference(aggregateContextClass, expression.symbol.owner)
         return contextReference?.let { context ->
-            val symbolName = expression.symbol.owner.name
-            val functionName = when {
-                symbolName.isSpecial -> "?"
-                else -> symbolName.asString()
-            }
+            val functionName = expression.getFunctionName()
             // We don't want to align the alignedOn function :)
             if (functionName == ALIGNED_ON_FUNCTION) return super.visitCall(expression)
 

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentTransformer.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentTransformer.kt
@@ -1,6 +1,7 @@
 package it.unibo.collektive
 
 import it.unibo.collektive.utils.branch.addBranchAlignment
+import it.unibo.collektive.utils.branch.findAggregateReference
 import it.unibo.collektive.utils.call.buildAlignedOnCall
 import it.unibo.collektive.utils.common.AggregateFunctionNames.ALIGNED_ON_FUNCTION
 import it.unibo.collektive.utils.statement.irStatement
@@ -70,7 +71,10 @@ class AlignmentTransformer(
         with (logger) {
             branch.addBranchAlignment(pluginContext, aggregateContextClass, aggregateLambdaBody, alignedOnFunction)
         }
-        return super.visitBranch(branch)
+        val aggregateReference = branch.result.findAggregateReference(aggregateContextClass)
+        return super.visitBranch(branch.transform(
+            FieldProjectionVisitor(pluginContext, logger, aggregateContextClass, aggregateReference), null)
+        )
     }
 
     override fun visitElseBranch(branch: IrElseBranch): IrElseBranch {
@@ -83,6 +87,9 @@ class AlignmentTransformer(
                 false
             )
         }
-        return super.visitElseBranch(branch)
+        val aggregateReference = branch.result.findAggregateReference(aggregateContextClass)
+        return super.visitElseBranch(branch.transform(
+            FieldProjectionVisitor(pluginContext, logger, aggregateContextClass, aggregateReference), null)
+        )
     }
 }

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/FieldProjectionVisitor.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/FieldProjectionVisitor.kt
@@ -1,0 +1,72 @@
+package it.unibo.collektive
+
+import it.unibo.collektive.utils.common.AggregateFunctionNames.FIELD_CLASS
+import it.unibo.collektive.utils.common.AggregateFunctionNames.PROJECT_FUNCTION
+import it.unibo.collektive.utils.common.putTypeArgument
+import it.unibo.collektive.utils.logging.error
+import it.unibo.collektive.utils.statement.irStatement
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrGetValue
+import org.jetbrains.kotlin.ir.expressions.putArgument
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+class FieldProjectionVisitor(
+    private val pluginContext: IrPluginContext,
+    private val logger: MessageCollector,
+    private val aggregateContextClass: IrClass,
+    private val aggregateReference: IrExpression?,
+) : IrElementTransformerVoid() {
+
+    private val projectFunction by lazy {
+        aggregateContextClass.functions
+            .filter { it.name == Name.identifier(PROJECT_FUNCTION) }
+            .firstOrNull()
+    }
+
+    override fun visitGetValue(expression: IrGetValue): IrExpression {
+        if (expression.type.classFqName == FqName(FIELD_CLASS)) {
+            aggregateReference?.let { aggregateRef ->
+                projectFunction?.let { projectFunc ->
+                    return wrapInProjectFunction(expression, aggregateRef, projectFunc)
+                } ?: logger.error(
+                    """
+                        Fail to look up the `project` function to perform the field projection.
+                        This can happen if the `AggregateContext` class is not found by the compiler plugin.
+                    """.trimIndent()
+                )
+            } ?: logger.error(
+                """
+                    Fail to look up the aggregate context reference to perform the field projection.
+                    This can happen if the aggregate context reference is not available in the current scope,
+                    and likely means that a field operation is being performed outside of an aggregate scope.
+                """.trimIndent()
+            )
+        }
+        return super.visitGetValue(expression)
+    }
+
+    private fun wrapInProjectFunction(
+        expression: IrExpression,
+        context: IrExpression,
+        function: IrFunction
+    ): IrExpression {
+        return irStatement(pluginContext, function, expression) {
+            irCall(function).apply {
+                // Set generics type
+                putTypeArgument(expression.type)
+                // Set aggregate context
+                putArgument(function.dispatchReceiverParameter!!, context)
+                putValueArgument(0, expression)
+            }
+        }
+    }
+}

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/FieldProjectionVisitor.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/FieldProjectionVisitor.kt
@@ -39,7 +39,7 @@ class FieldProjectionVisitor(
                     return wrapInProjectFunction(expression, aggregateRef, projectFunc)
                 } ?: logger.error(
                     """
-                        Fail to look up the `project` function to perform the field projection.
+                        Failed to look up the `Field.project` function required for performing the field projection.
                         This can happen if the `AggregateContext` class is not found by the compiler plugin.
                     """.trimIndent()
                 )

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/branch/BranchUtils.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/branch/BranchUtils.kt
@@ -43,7 +43,7 @@ private fun IrBlock.findAggregateReference(aggregateContextClass: IrClass): IrEx
     return aggregateContextReferences.filterNotNull().firstOrNull()
 }
 
-private fun IrExpression.findAggregateReference(aggregateContextClass: IrClass): IrExpression? = when (this) {
+internal fun IrExpression.findAggregateReference(aggregateContextClass: IrClass): IrExpression? = when (this) {
     is IrBlock -> findAggregateReference(aggregateContextClass)
     is IrCall -> collectAggregateContextReference(aggregateContextClass, this)
         ?: collectAggregateContextReference(aggregateContextClass, symbol.owner)

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/call/CallAlignment.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/call/CallAlignment.kt
@@ -44,7 +44,12 @@ fun IrSingleStatementBuilder.buildAlignedOnCall(
         // Set aggregate context
         putArgument(alignedOnFunction.dispatchReceiverParameter!!, aggregateContextReference)
         // Set the argument that is going to be push in the stack
-        val functionName = expression.symbol.owner.name.asString()
+        val symbolName = expression.symbol.owner.name
+        val functionName = when {
+            symbolName.isSpecial -> "?"
+            else -> symbolName.asString()
+        }
+        //
         val count = data[functionName]!! // Here the key should be present!
         putValueArgument(
             irString("$functionName.$count"),

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/call/CallAlignment.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/call/CallAlignment.kt
@@ -1,6 +1,7 @@
 package it.unibo.collektive.utils.call
 
 import it.unibo.collektive.AlignedData
+import it.unibo.collektive.utils.common.getFunctionName
 import it.unibo.collektive.utils.common.getLambdaType
 import it.unibo.collektive.utils.common.putTypeArgument
 import it.unibo.collektive.utils.common.putValueArgument
@@ -44,12 +45,7 @@ fun IrSingleStatementBuilder.buildAlignedOnCall(
         // Set aggregate context
         putArgument(alignedOnFunction.dispatchReceiverParameter!!, aggregateContextReference)
         // Set the argument that is going to be push in the stack
-        val symbolName = expression.symbol.owner.name
-        val functionName = when {
-            symbolName.isSpecial -> "?"
-            else -> symbolName.asString()
-        }
-        //
+        val functionName = expression.getFunctionName()
         val count = data[functionName]!! // Here the key should be present!
         putValueArgument(
             irString("$functionName.$count"),

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/common/AggregateFunctionNames.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/common/AggregateFunctionNames.kt
@@ -2,7 +2,7 @@ package it.unibo.collektive.utils.common
 
 object AggregateFunctionNames {
     const val ALIGNED_ON_FUNCTION = "alignedOn"
-    const val AGGREGATE_FUNCTION = "aggregate"
-    const val ALIGNED_ON_FUNCTION_FQ_NAME = "it.unibo.collektive.aggregate.AggregateContext.alignedOn"
     const val AGGREGATE_CONTEXT_CLASS = "it.unibo.collektive.aggregate.AggregateContext"
+    const val FIELD_CLASS = "it.unibo.collektive.field.Field"
+    const val PROJECT_FUNCTION = "project"
 }

--- a/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/common/IrElementUtils.kt
+++ b/plugin/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/common/IrElementUtils.kt
@@ -55,3 +55,11 @@ internal fun getLambdaType(pluginContext: IrPluginContext, lambda: IrSimpleFunct
         throw ClassNotFoundException("Unable to reference ${classFqn.parent()}")
     }
 }
+
+internal fun IrCall.getFunctionName(): String {
+    val symbolName = symbol.owner.name
+    return when {
+        symbolName.isSpecial -> "?"
+        else -> symbolName.asString()
+    }
+}


### PR DESCRIPTION
This PR extends the compiler plugin to support the "projection" of fields when used inside the bodies of a branch.

This is an implementation of rule `[E-FLD]` as specified in [this paper](https://doi.org/10.1145/3285956)

This PR closes #171
