### PR TITLE
fix: incarnation to adapt to new Alchemist version (32.0.0)

### DIFF
--- a/alchemist-incarnation-collektive/src/main/kotlin/it/unibo/alchemist/CollektiveIncarnation.kt
+++ b/alchemist-incarnation-collektive/src/main/kotlin/it/unibo/alchemist/CollektiveIncarnation.kt
@@ -78,7 +78,7 @@ class CollektiveIncarnation<P> : Incarnation<Any?, P> where P : Position<P> {
 
     override fun createMolecule(molecule: String) = SimpleMolecule(molecule)
 
-    override fun createConcentration(concentration: String?) = concentration
+    override fun createConcentration(p0: Any?): Any? = p0
 
     override fun createConcentration() = Unit
 

--- a/alchemist-incarnation-collektive/src/main/kotlin/it/unibo/alchemist/CollektiveIncarnation.kt
+++ b/alchemist-incarnation-collektive/src/main/kotlin/it/unibo/alchemist/CollektiveIncarnation.kt
@@ -78,7 +78,7 @@ class CollektiveIncarnation<P> : Incarnation<Any?, P> where P : Position<P> {
 
     override fun createMolecule(molecule: String) = SimpleMolecule(molecule)
 
-    override fun createConcentration(p0: Any?): Any? = p0
+    override fun createConcentration(concentration: Any?): Any? = concentration
 
     override fun createConcentration() = Unit
 

--- a/alchemist-incarnation-collektive/src/main/kotlin/it/unibo/collektive/alchemist/device/sensors/EnvironmentVariables.kt
+++ b/alchemist-incarnation-collektive/src/main/kotlin/it/unibo/collektive/alchemist/device/sensors/EnvironmentVariables.kt
@@ -20,7 +20,7 @@ interface EnvironmentVariables {
     fun <T> getOrDefault(name: String, default: T): T
 
     /**
-     * Check if the variable with the given [name] is defined.
+     * Check if the variable with the given [name] is defined inside the environment.
      */
     fun isDefined(name: String): Boolean
 

--- a/alchemist-incarnation-collektive/src/test/resources/it/unibo/collektive/test/use-environment-variables.yml
+++ b/alchemist-incarnation-collektive/src/test/resources/it/unibo/collektive/test/use-environment-variables.yml
@@ -1,0 +1,32 @@
+network-model:
+  type: ConnectWithinDistance
+  parameters: [ 5 ]
+
+incarnation: collektive
+
+_pool: &program
+  - time-distribution: 1
+    program:
+      name: Gradient
+      source-sets:
+        - src/test/resources/it/unibo/collektive/test/kotlin
+      code: |
+        import my.test.*
+        import it.unibo.collektive.alchemist.device.sensors.EnvironmentVariables
+      entrypoint: gradient(get("source"))
+
+deployments:
+  - type: Rectangle
+    parameters: [ 10, 0, 0, 2, 2 ]
+    programs:
+      - *program
+    contents:
+      - molecule: source
+        concentration: false
+  - type: Point
+    parameters: [ 1, 1 ]
+    programs:
+      - *program
+    contents:
+      - molecule: source
+        concentration: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-alchemist = "31.0.6"
+alchemist = "32.0.0"
 build-config = "5.3.5"
 coroutines = "1.8.0"
 dokka = "1.9.20"


### PR DESCRIPTION
From [32.0.0](https://github.com/AlchemistSimulator/Alchemist/releases/tag/32.0.0) Alchemist supports arbitrarily-typed concentrations in incarnation ([#3217](https://github.com/AlchemistSimulator/Alchemist/pull/3217))