### PR TITLE
fix: fail fast when the collektive compiler plugin is not applied

### DIFF
--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentIrGenerationExtension.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentIrGenerationExtension.kt
@@ -69,7 +69,6 @@ class AlignmentIrGenerationExtension(private val logger: MessageCollector) : IrG
             ),
             null,
         )
-
         /*
          This transformation changes the `isCompilerPluginApplied` function to return true.
          */

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentIrGenerationExtension.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentIrGenerationExtension.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.name.Name
  * The generation extension is used to register the transformer plugin, which is going to modify
  * the IR using the function responsible for the alignment.
  */
+@Suppress("ReturnCount")
 class AlignmentIrGenerationExtension(private val logger: MessageCollector) : IrGenerationExtension {
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
         // Aggregate Context class that has the reference to the stack

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/transformers/EnabledCompilerPluginTransformer.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/transformers/EnabledCompilerPluginTransformer.kt
@@ -11,11 +11,14 @@ import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
+/**
+ * This transformer replaces the body of the function `isEnabledFunction` with a return statement that returns `true`.
+ */
 class EnabledCompilerPluginTransformer(
     private val pluginContext: IrPluginContext,
     private val logger: MessageCollector,
     private val isEnabledFunction: IrFunction,
-): IrElementTransformerVoid() {
+) : IrElementTransformerVoid() {
 
     override fun visitFunction(declaration: IrFunction): IrStatement {
         if (declaration.name == isEnabledFunction.name) {

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/transformers/EnabledCompilerPluginTransformer.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/transformers/EnabledCompilerPluginTransformer.kt
@@ -1,0 +1,30 @@
+package it.unibo.collektive.transformers
+
+import it.unibo.collektive.utils.logging.info
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irBoolean
+import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+
+class EnabledCompilerPluginTransformer(
+    private val pluginContext: IrPluginContext,
+    private val logger: MessageCollector,
+    private val isEnabledFunction: IrFunction,
+): IrElementTransformerVoid() {
+
+    override fun visitFunction(declaration: IrFunction): IrStatement {
+        if (declaration.name == isEnabledFunction.name) {
+            logger.info("Transforming the function ${declaration.name} to return `true` because the plugin is enabled.")
+            declaration.body = DeclarationIrBuilder(pluginContext, declaration.symbol).irBlockBody {
+                +irReturn(irBoolean(true))
+            }
+            return declaration
+        }
+        return super.visitFunction(declaration)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/common/AggregateFunctionNames.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/common/AggregateFunctionNames.kt
@@ -23,4 +23,9 @@ object AggregateFunctionNames {
      * The name of the function that is used to project the fields.
      */
     const val PROJECT_FUNCTION = "project"
+
+    /**
+     * The name of the function showing if the compiler plugin is applied.
+     */
+    const val IS_COMPILER_PLUGIN_APPLIED_FUNCTION = "isCompilerPluginApplied"
 }

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/Collektive.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/Collektive.kt
@@ -87,7 +87,7 @@ class Collektive<ID : Any, R>(
 
         private fun checkCompilerPluginApplied() = require(isCompilerPluginApplied()) {
             """
-                The collektive compiler plugin is not applied.
+                The collektive compiler plugin has not been applied.
                 Please add the following to your build.gradle.kts:
                 
                 plugins {

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/api/impl/AggregateContext.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/api/impl/AggregateContext.kt
@@ -134,3 +134,9 @@ fun <ID : Any, T> Aggregate<ID>.project(field: Field<ID, T>): Field<ID, T> {
         )
     }
 }
+
+/**
+ * This function returns true if the Collektive compiler plugin is applied to the current project.
+ */
+@Suppress("FunctionOnlyReturningConstant")
+fun isCompilerPluginApplied(): Boolean = false

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/TestAlignment.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/TestAlignment.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldContain
 import it.unibo.collektive.Collektive.Companion.aggregate
 import it.unibo.collektive.aggregate.api.Aggregate
+import it.unibo.collektive.aggregate.api.impl.isCompilerPluginApplied
 import it.unibo.collektive.aggregate.api.operators.neighboringViaExchange
 import it.unibo.collektive.aggregate.api.operators.share
 import it.unibo.collektive.field.Field
@@ -77,5 +78,8 @@ class TestAlignment : StringSpec({
         fun foo(aggregate: Aggregate<Int>) = aggregate.neighboringViaExchange(x)
         fun bar(aggregate: Aggregate<Int>) = aggregate.neighboringViaExchange(x)
         acProgram { foo(this) } shouldNot alignWith { bar(this) }
+    }
+    "The isCompilerPluginApplied function must return true when the compiler plugin is applied" {
+        isCompilerPluginApplied() shouldBe true
     }
 })


### PR DESCRIPTION
This PR introduces a check preventing the run of Collektive programs when the compiler plugin is not applied.