### PR TITLE
feat(field): add `replaceMatching` method replacing the values in a field matching a given predicate

### DIFF
--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/operations/Fields.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/operations/Fields.kt
@@ -91,3 +91,11 @@ inline fun <ID : Any, T> Field<ID, T>.none(crossinline predicate: (T) -> Boolean
  */
 inline fun <ID : Any, T> Field<ID, T>.noneWithSelf(crossinline predicate: (T) -> Boolean): Boolean =
     !anyWithSelf(predicate)
+
+/**
+ * Returns a new field containing [replaceWith] for each element that satisfies the [predicate].
+ */
+inline fun <ID : Any, T> Field<ID, T>.replaceMatching(
+    replaceWith: T,
+    crossinline predicate: (T) -> Boolean,
+): Field<ID, T> = map { if (predicate(it)) replaceWith else it }

--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/operations/Fields.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/operations/Fields.kt
@@ -95,7 +95,15 @@ inline fun <ID : Any, T> Field<ID, T>.noneWithSelf(crossinline predicate: (T) ->
 /**
  * Returns a new field containing [replaceWith] for each element that satisfies the [predicate].
  */
+inline fun <ID : Any, T> Field<ID, T>.replaceMatchingWithId(
+    replaceWith: T,
+    crossinline predicate: (ID, T) -> Boolean,
+): Field<ID, T> = mapWithId { id, value -> if (predicate(id, value)) replaceWith else value }
+
+/**
+ * Returns a new field containing [replaceWith] for each element that satisfies the [predicate].
+ */
 inline fun <ID : Any, T> Field<ID, T>.replaceMatching(
     replaceWith: T,
     crossinline predicate: (T) -> Boolean,
-): Field<ID, T> = map { if (predicate(it)) replaceWith else it }
+): Field<ID, T> = replaceMatchingWithId(replaceWith) { _, value -> predicate(value) }

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
@@ -8,6 +8,7 @@ import it.unibo.collektive.field.Field.Companion.fold
 import it.unibo.collektive.field.Field.Companion.foldWithId
 import it.unibo.collektive.field.Field.Companion.hood
 import it.unibo.collektive.field.Field.Companion.hoodWithId
+import it.unibo.collektive.field.operations.replaceMatching
 
 class FieldOpsTest : StringSpec({
     val emptyField = Field(0, "localVal")
@@ -70,5 +71,14 @@ class FieldOpsTest : StringSpec({
     "A field should return a sequence containing all the values" {
         field.asSequence().toList() shouldContainAll
             sequenceOf(0 to 0, 1 to 10, 2 to 20).toList()
+    }
+    "The replaceMatching on an empty field should return an empty field" {
+        emptyField.replaceMatching("replaced") { it == "no-data" } shouldBe emptyField
+    }
+    "The replaceMatching should return the same field if the predicate is not satisfied" {
+        field.replaceMatching(Int.MAX_VALUE) { it == 42 } shouldBe field
+    }
+    "The replaceMatching should return a field with the replaced values" {
+        field.replaceMatching(42) { it == 10 } shouldBe Field(0, 0, mapOf(1 to 42, 2 to 20))
     }
 })


### PR DESCRIPTION
This PR introduces the `replaceMatching` method over `Field`  that replaces each value in the field with a provided value if the previous value matches the provided predicate.

Closes #549 