### PR TITLE
feat(field): change `toString` representation for `Field`

### DIFF
--- a/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
+++ b/dsl/src/commonMain/kotlin/it/unibo/collektive/field/Field.kt
@@ -217,7 +217,7 @@ internal abstract class AbstractField<ID : Any, T>(
 
     protected abstract fun <R> mapOthersAsSequence(transform: (ID, T) -> R): Sequence<Pair<ID, R>>
 
-    final override fun toString() = toMap().toString()
+    final override fun toString() = "ϕ(localId=$localId, localValue=$localValue, neighbors=${neighborsMap()})"
 }
 
 internal class ArrayBasedField<ID : Any, T>(

--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/field/FieldOpsTest.kt
@@ -98,4 +98,9 @@ class FieldOpsTest : StringSpec({
             mapOf(1 to 11, 2 to 21, 3 to 16),
         )
     }
+    "The string representation of a field should contain the local id and the local value and the neighbors" {
+        emptyField.toString() shouldBe "ϕ(localId=0, localValue=localVal, neighbors={})"
+        field.toString() shouldBe "ϕ(localId=0, localValue=0, neighbors={1=10, 2=20})"
+        fulfilledField.toString() shouldBe "ϕ(localId=0, localValue=0, neighbors={1=10, 2=20, 3=15})"
+    }
 })


### PR DESCRIPTION
This PR changes the `Field` representation via `toString`

Closes #557 