### PR TITLE
refactor: move warnings and error in appropriate objects following the jetbrains convention

### DIFF
--- a/compiler-plugin-test/src/test/kotlin/it/unibo/collektive/test/ExplicitAlignTest.kt
+++ b/compiler-plugin-test/src/test/kotlin/it/unibo/collektive/test/ExplicitAlignTest.kt
@@ -3,6 +3,7 @@ package it.unibo.collektive.test
 import io.kotest.core.spec.style.FreeSpec
 import it.unibo.collektive.test.util.CompileUtils.asTestingProgram
 import it.unibo.collektive.test.util.CompileUtils.warning
+import it.unibo.collektive.utils.common.AggregateFunctionNames
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 @OptIn(ExperimentalCompilerApi::class)
@@ -11,7 +12,7 @@ class ExplicitAlignTest : FreeSpec({
         val code = codeTemplate.format("align(null)").asTestingProgram("ExplicitAlign.kt")
         "should produce a warning when used explicitly" - {
             code shouldCompileWith warning(
-                EXPECTED_WARNING_MESSAGE.format("align"),
+                EXPECTED_WARNING_MESSAGE.format(AggregateFunctionNames.ALIGN_FUNCTION_FQ_NAME),
             )
         }
     }
@@ -19,13 +20,14 @@ class ExplicitAlignTest : FreeSpec({
         val code = codeTemplate.format("dealign()").asTestingProgram("ExplicitDeAlign.kt")
         "should produce a warning when used explicitly" - {
             code shouldCompileWith warning(
-                EXPECTED_WARNING_MESSAGE.format("dealign"),
+                EXPECTED_WARNING_MESSAGE.format(AggregateFunctionNames.DEALIGN_FUNCTION_FQ_NAME),
             )
         }
     }
 }) {
     companion object {
-        const val EXPECTED_WARNING_MESSAGE = "Warning: '%s' method should not be explicitly used"
+//        const val EXPECTED_WARNING_MESSAGE = "Warning: '%s' method should not be explicitly used"
+        const val EXPECTED_WARNING_MESSAGE = "The function '%s' should not be called explicitly"
 
         val codeTemplate = """
         import it.unibo.collektive.aggregate.api.Aggregate

--- a/compiler-plugin-test/src/test/kotlin/it/unibo/collektive/test/IterationWithoutAlignSpec.kt
+++ b/compiler-plugin-test/src/test/kotlin/it/unibo/collektive/test/IterationWithoutAlignSpec.kt
@@ -5,7 +5,6 @@ import io.kotest.data.forAll
 import io.kotest.data.headers
 import io.kotest.data.row
 import io.kotest.data.table
-import it.unibo.collektive.frontend.checkers.NoAlignInsideLoop
 import it.unibo.collektive.test.util.CompileUtils
 import it.unibo.collektive.test.util.CompileUtils.asTestingProgram
 import it.unibo.collektive.test.util.CompileUtils.noWarning
@@ -16,6 +15,14 @@ import java.io.FileNotFoundException
 
 @OptIn(ExperimentalCompilerApi::class)
 class IterationWithoutAlignSpec : FreeSpec({
+
+    fun expectedWarning(functionName: String): String =
+        """
+            Aggregate function '$functionName' has been called inside a loop construct without explicit alignment.
+            The same path may generate interactions more than once, leading to ambiguous alignment.
+            
+            Consider to wrap the function into the 'alignedOn' method with a unique element.
+        """.trimIndent()
 
     "When iterating an Aggregate function" - {
         forAll(testedAggregateFunctions) { functionCall ->
@@ -38,7 +45,7 @@ class IterationWithoutAlignSpec : FreeSpec({
 
                     "should compile producing a warning" - {
                         code shouldCompileWith warning(
-                            NoAlignInsideLoop.createWarning(functionName),
+                            expectedWarning(functionName),
                         )
                     }
                 }
@@ -58,7 +65,7 @@ class IterationWithoutAlignSpec : FreeSpec({
 
                     "should compile producing a warning" - {
                         code shouldCompileWith warning(
-                            NoAlignInsideLoop.createWarning(functionName),
+                            expectedWarning(functionName),
                         )
                     }
                 }

--- a/compiler-plugin-test/src/test/kotlin/it/unibo/collektive/test/IterationWithoutAlignSpec.kt
+++ b/compiler-plugin-test/src/test/kotlin/it/unibo/collektive/test/IterationWithoutAlignSpec.kt
@@ -15,7 +15,6 @@ import java.io.FileNotFoundException
 
 @OptIn(ExperimentalCompilerApi::class)
 class IterationWithoutAlignSpec : FreeSpec({
-
     fun expectedWarning(functionName: String): String =
         """
             Aggregate function '$functionName' has been called inside a loop construct without explicit alignment.

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentIrGenerationExtension.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/AlignmentIrGenerationExtension.kt
@@ -4,8 +4,8 @@ package it.unibo.collektive
 
 import it.unibo.collektive.transformers.AggregateCallTransformer
 import it.unibo.collektive.utils.common.AggregateFunctionNames
-import it.unibo.collektive.utils.common.AggregateFunctionNames.ALIGN_FUNCTION
-import it.unibo.collektive.utils.common.AggregateFunctionNames.DEALIGN_RAW_FUNCTION
+import it.unibo.collektive.utils.common.AggregateFunctionNames.ALIGN_FUNCTION_NAME
+import it.unibo.collektive.utils.common.AggregateFunctionNames.DEALIGN_FUNCTION_NAME
 import it.unibo.collektive.utils.common.AggregateFunctionNames.PROJECT_FUNCTION
 import it.unibo.collektive.utils.logging.error
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
@@ -30,7 +30,7 @@ class AlignmentIrGenerationExtension(private val logger: MessageCollector) : IrG
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
         // Aggregate Context class that has the reference to the stack
         val aggregateClass = pluginContext.referenceClass(
-            ClassId.topLevel(FqName(AggregateFunctionNames.AGGREGATE_CLASS)),
+            ClassId.topLevel(FqName(AggregateFunctionNames.AGGREGATE_CLASS_FQ_NAME)),
         )
         if (aggregateClass == null) {
             return logger.error("Unable to find the aggregate class")
@@ -44,11 +44,11 @@ class AlignmentIrGenerationExtension(private val logger: MessageCollector) : IrG
         ).firstOrNull() ?: return logger.error("Unable to find the 'project' function")
 
         // Function that handles the alignment
-        val alignRawFunction = aggregateClass.getFunctionReferenceWithName(ALIGN_FUNCTION)
-            ?: return logger.error("Unable to find the `$ALIGN_FUNCTION` function")
+        val alignRawFunction = aggregateClass.getFunctionReferenceWithName(ALIGN_FUNCTION_NAME)
+            ?: return logger.error("Unable to find the '$ALIGN_FUNCTION_NAME' function")
 
-        val dealignFunction = aggregateClass.getFunctionReferenceWithName(DEALIGN_RAW_FUNCTION)
-            ?: return logger.error("Unable to find the `$DEALIGN_RAW_FUNCTION` function")
+        val dealignFunction = aggregateClass.getFunctionReferenceWithName(DEALIGN_FUNCTION_NAME)
+            ?: return logger.error("Unable to find the '$DEALIGN_FUNCTION_NAME' function")
 
         /*
          This applies the alignment call on all the aggregate functions

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/CheckersUtility.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/CheckersUtility.kt
@@ -1,10 +1,6 @@
 package it.unibo.collektive.frontend.checkers
 
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactory1
-import org.jetbrains.kotlin.diagnostics.Severity
-import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
-import org.jetbrains.kotlin.diagnostics.warning1
+import it.unibo.collektive.utils.common.AggregateFunctionNames.AGGREGATE_CLASS_NAME
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
@@ -16,25 +12,22 @@ import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.expressions.unwrapExpression
 import org.jetbrains.kotlin.fir.references.toResolvedFunctionSymbol
-import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
-import org.jetbrains.kotlin.psi.KtFunction
 
 /**
  * Collection of utilities for FIR checkers.
  */
 object CheckersUtility {
-//    /**
-//     * Object containing the types of errors/warnings reported by this extension.
-//     */
-//    object PluginErrors {
-//        /**
-//         * Warning generated on a dot call.
-//         */
-//        val DOT_CALL_WARNING by warning1<PsiElement, String>(
-//            SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
-//        )
-//    }
+    //    /**
+    //     * Object containing the types of errors/warnings reported by this extension.
+    //     */
+    //    object PluginErrors {
+    //        /**
+    //         * Warning generated on a dot call.
+    //         */
+    //        val DOT_CALL_WARNING by warning1<PsiElement, String>(
+    //            SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
+    //        )
+    //    }
 
     /**
      * Checks is a specific receiver parameter is [Aggregate][it.unibo.collektive.aggregate.api.Aggregate]
@@ -45,7 +38,7 @@ object CheckersUtility {
      * It returns **true** if it's an `Aggregate` function, **false** otherwise.
      */
     fun FirReceiverParameter.isAggregate(session: FirSession): Boolean =
-        typeRef.toClassLikeSymbol(session)?.name?.asString() == "Aggregate"
+        typeRef.toClassLikeSymbol(session)?.name?.asString() == AGGREGATE_CLASS_NAME
 
     /**
      * Checks if the function that is called is an [Aggregate][it.unibo.collektive.aggregate.api.Aggregate] one
@@ -58,7 +51,7 @@ object CheckersUtility {
     fun FirFunctionCall.isAggregate(session: FirSession): Boolean {
         val callableSymbol = toResolvedCallableSymbol()
         return callableSymbol?.receiverParameter?.isAggregate(session) == true ||
-            callableSymbol?.getContainingClassSymbol(session)?.name?.asString() == "Aggregate"
+            callableSymbol?.getContainingClassSymbol(session)?.name?.asString() == AGGREGATE_CLASS_NAME
     }
 
     /**

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/CheckersUtility.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/CheckersUtility.kt
@@ -1,6 +1,8 @@
 package it.unibo.collektive.frontend.checkers
 
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactory1
+import org.jetbrains.kotlin.diagnostics.Severity
 import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
 import org.jetbrains.kotlin.diagnostics.warning1
 import org.jetbrains.kotlin.fir.FirElement
@@ -14,22 +16,25 @@ import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.expressions.unwrapExpression
 import org.jetbrains.kotlin.fir.references.toResolvedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.psi.KtFunction
 
 /**
  * Collection of utilities for FIR checkers.
  */
 object CheckersUtility {
-    /**
-     * Object containing the types of errors/warnings reported by this extension.
-     */
-    object PluginErrors {
-        /**
-         * Warning generated on a dot call.
-         */
-        val DOT_CALL_WARNING by warning1<PsiElement, String>(
-            SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
-        )
-    }
+//    /**
+//     * Object containing the types of errors/warnings reported by this extension.
+//     */
+//    object PluginErrors {
+//        /**
+//         * Warning generated on a dot call.
+//         */
+//        val DOT_CALL_WARNING by warning1<PsiElement, String>(
+//            SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
+//        )
+//    }
 
     /**
      * Checks is a specific receiver parameter is [Aggregate][it.unibo.collektive.aggregate.api.Aggregate]

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/CheckersUtility.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/CheckersUtility.kt
@@ -17,18 +17,6 @@ import org.jetbrains.kotlin.fir.references.toResolvedFunctionSymbol
  * Collection of utilities for FIR checkers.
  */
 object CheckersUtility {
-    //    /**
-    //     * Object containing the types of errors/warnings reported by this extension.
-    //     */
-    //    object PluginErrors {
-    //        /**
-    //         * Warning generated on a dot call.
-    //         */
-    //        val DOT_CALL_WARNING by warning1<PsiElement, String>(
-    //            SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
-    //        )
-    //    }
-
     /**
      * Checks is a specific receiver parameter is [Aggregate][it.unibo.collektive.aggregate.api.Aggregate]
      * (`Aggregate<ID>.example()`).

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/ExplicitAlignDealign.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/ExplicitAlignDealign.kt
@@ -1,6 +1,8 @@
 package it.unibo.collektive.frontend.checkers
 
+import it.unibo.collektive.frontend.checkers.CheckersUtility.fqName
 import it.unibo.collektive.frontend.checkers.CheckersUtility.isInsideAggregateFunction
+import it.unibo.collektive.utils.common.AggregateFunctionNames
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
@@ -13,19 +15,19 @@ import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
  */
 object ExplicitAlignDealign : FirFunctionCallChecker(MppCheckerKind.Common) {
     override fun check(expression: FirFunctionCall, context: CheckerContext, reporter: DiagnosticReporter) {
-        val calleeName = expression.calleeReference.name.identifier
-        if (calleeName in EXCLUDE_FUNCTION && context.isInsideAggregateFunction()) {
+        val fqnCalleeName = expression.fqName()
+        if (fqnCalleeName in FORBIDDEN_FUNCTIONS && context.isInsideAggregateFunction()) {
             reporter.reportOn(
                 expression.calleeReference.source,
                 FirCollektiveErrors.FORBIDDEN_FUNCTION,
-                calleeName,
+                fqnCalleeName,
                 context,
             )
         }
     }
 
-    private val EXCLUDE_FUNCTION = listOf(
-        "align",
-        "dealign",
+    private val FORBIDDEN_FUNCTIONS = listOf(
+        AggregateFunctionNames.ALIGNED_ON_FUNCTION_FQ_NAME,
+        AggregateFunctionNames.DEALIGN_FUNCTION_FQ_NAME,
     )
 }

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/ExplicitAlignDealign.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/ExplicitAlignDealign.kt
@@ -19,7 +19,7 @@ object ExplicitAlignDealign : FirFunctionCallChecker(MppCheckerKind.Common) {
         if (fqnCalleeName in FORBIDDEN_FUNCTIONS && context.isInsideAggregateFunction()) {
             reporter.reportOn(
                 expression.calleeReference.source,
-                FirCollektiveErrors.FORBIDDEN_FUNCTION,
+                FirCollektiveErrors.FORBIDDEN_FUNCTION_CALL,
                 fqnCalleeName,
                 context,
             )
@@ -27,7 +27,7 @@ object ExplicitAlignDealign : FirFunctionCallChecker(MppCheckerKind.Common) {
     }
 
     private val FORBIDDEN_FUNCTIONS = listOf(
-        AggregateFunctionNames.ALIGNED_ON_FUNCTION_FQ_NAME,
+        AggregateFunctionNames.ALIGN_FUNCTION_FQ_NAME,
         AggregateFunctionNames.DEALIGN_FUNCTION_FQ_NAME,
     )
 }

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/ExplicitAlignDealign.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/ExplicitAlignDealign.kt
@@ -1,6 +1,5 @@
 package it.unibo.collektive.frontend.checkers
 
-import it.unibo.collektive.frontend.checkers.CheckersUtility.PluginErrors
 import it.unibo.collektive.frontend.checkers.CheckersUtility.isInsideAggregateFunction
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
@@ -15,13 +14,18 @@ import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 object ExplicitAlignDealign : FirFunctionCallChecker(MppCheckerKind.Common) {
     override fun check(expression: FirFunctionCall, context: CheckerContext, reporter: DiagnosticReporter) {
         val calleeName = expression.calleeReference.name.identifier
-        if ((calleeName == "align" || calleeName == "dealign") && context.isInsideAggregateFunction()) {
+        if (calleeName in EXCLUDE_FUNCTION && context.isInsideAggregateFunction()) {
             reporter.reportOn(
                 expression.calleeReference.source,
-                PluginErrors.DOT_CALL_WARNING,
-                "Warning: '$calleeName' method should not be explicitly used",
+                FirCollektiveErrors.FORBIDDEN_FUNCTION,
+                calleeName,
                 context,
             )
         }
     }
+
+    private val EXCLUDE_FUNCTION = listOf(
+        "align",
+        "dealign",
+    )
 }

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/FirCollektiveErrors.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/FirCollektiveErrors.kt
@@ -13,8 +13,18 @@ import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
 import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.warning1
 
+/**
+ * Error messages for the Collektive compiler plugin.
+ */
 object FirCollektiveErrors {
+    /**
+     * Warning raised when a forbidden function is called.
+     */
     val FORBIDDEN_FUNCTION by warning1<PsiElement, String>(SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT)
+
+    /**
+     * Warning raised when an aggregate function is called inside an iteration construct.
+     */
     val AGGREGATE_FUNCTION_INSIDE_ITERATION by warning1<PsiElement, String>(
         SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
     )

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/FirCollektiveErrors.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/FirCollektiveErrors.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Danilo Pianini, Nicolas Farabegoli, Elisa Tronetti,
+ * and all authors listed in the `build.gradle.kts` and the generated `pom.xml` file.
+ *
+ * This file is part of Collektive, and is distributed under the terms of the Apache License 2.0,
+ * as described in the LICENSE file in this project's repository's top directory.
+ */
+
+package it.unibo.collektive.frontend.checkers
+
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
+import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
+import org.jetbrains.kotlin.diagnostics.warning1
+
+object FirCollektiveErrors {
+    val FORBIDDEN_FUNCTION by warning1<PsiElement, String>(SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT)
+    val AGGREGATE_FUNCTION_INSIDE_ITERATION by warning1<PsiElement, String>(
+        SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
+    )
+
+    init {
+        RootDiagnosticRendererFactory.registerFactory(KtDefaultErrorMessagesCollektive)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/FirCollektiveErrors.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/FirCollektiveErrors.kt
@@ -9,7 +9,7 @@
 package it.unibo.collektive.frontend.checkers
 
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
+import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT
 import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.warning1
 
@@ -20,14 +20,12 @@ object FirCollektiveErrors {
     /**
      * Warning raised when a forbidden function is called.
      */
-    val FORBIDDEN_FUNCTION by warning1<PsiElement, String>(SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT)
+    val FORBIDDEN_FUNCTION_CALL by warning1<PsiElement, String>(CALL_ELEMENT_WITH_DOT)
 
     /**
      * Warning raised when an aggregate function is called inside an iteration construct.
      */
-    val AGGREGATE_FUNCTION_INSIDE_ITERATION by warning1<PsiElement, String>(
-        SourceElementPositioningStrategies.CALL_ELEMENT_WITH_DOT,
-    )
+    val AGGREGATE_FUNCTION_INSIDE_ITERATION by warning1<PsiElement, String>(CALL_ELEMENT_WITH_DOT)
 
     init {
         RootDiagnosticRendererFactory.registerFactory(KtDefaultErrorMessagesCollektive)

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/KtDefaultErrorMessagesCollektive.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/KtDefaultErrorMessagesCollektive.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
 object KtDefaultErrorMessagesCollektive : BaseDiagnosticRendererFactory() {
     override val MAP = KtDiagnosticFactoryToRendererMap("Collektive").apply {
         put(
-            FirCollektiveErrors.FORBIDDEN_FUNCTION,
+            FirCollektiveErrors.FORBIDDEN_FUNCTION_CALL,
             "The function ''{0}'' should not be called explicitly",
             CommonRenderers.STRING,
         )

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/KtDefaultErrorMessagesCollektive.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/KtDefaultErrorMessagesCollektive.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Danilo Pianini, Nicolas Farabegoli, Elisa Tronetti,
+ * and all authors listed in the `build.gradle.kts` and the generated `pom.xml` file.
+ *
+ * This file is part of Collektive, and is distributed under the terms of the Apache License 2.0,
+ * as described in the LICENSE file in this project's repository's top directory.
+ */
+
+package it.unibo.collektive.frontend.checkers
+
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
+import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
+import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
+
+object KtDefaultErrorMessagesCollektive : BaseDiagnosticRendererFactory() {
+    override val MAP = KtDiagnosticFactoryToRendererMap("Collektive").apply {
+        put(
+            FirCollektiveErrors.FORBIDDEN_FUNCTION,
+            "The function ''{0}'' should not be called explicitly",
+            CommonRenderers.STRING,
+        )
+        put(
+            FirCollektiveErrors.AGGREGATE_FUNCTION_INSIDE_ITERATION,
+            """
+            Aggregate function ''{0}'' has been called inside a loop construct without explicit alignment.
+            The same path may generate interactions more than once, leading to ambiguous alignment.
+            
+            Consider to wrap the function into the ''alignedOn'' method with a unique element.
+            """.trimIndent(),
+            CommonRenderers.STRING,
+        )
+    }
+}

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/KtDefaultErrorMessagesCollektive.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/KtDefaultErrorMessagesCollektive.kt
@@ -12,6 +12,9 @@ import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
 
+/**
+ * Mapping between the errors and warnings defined in [FirCollektiveErrors] and their respective error messages.
+ */
 object KtDefaultErrorMessagesCollektive : BaseDiagnosticRendererFactory() {
     override val MAP = KtDiagnosticFactoryToRendererMap("Collektive").apply {
         put(

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/NoAlignInsideLoop.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/NoAlignInsideLoop.kt
@@ -29,22 +29,22 @@ object NoAlignInsideLoop : FirFunctionCallChecker(MppCheckerKind.Common) {
         "it.unibo.collektive.aggregate.api.Aggregate.dealign",
     )
 
-    /**
-     * Creates a warning for this checker, formatted with the [calleeName] that originated it.
-     */
-    fun createWarning(calleeName: String): String =
-        """
-        Warning: aggregate function '$calleeName' has been called inside a loop construct without explicit alignment.
-        The same path may generate interactions more than once, leading to ambiguous alignment.
-        for (element in collection) {
-            $calleeName(...) // Broken
-        }
-        for (element in collection) {
-            alignedOn(element) { // Manual alignment on element, assuming it is unique 
-                $calleeName(...)
-            }
-        }
-        """.trimIndent()
+//    /**
+//     * Creates a warning for this checker, formatted with the [calleeName] that originated it.
+//     */
+//    fun createWarning(calleeName: String): String =
+//        """
+//        Warning: aggregate function '$calleeName' has been called inside a loop construct without explicit alignment.
+//        The same path may generate interactions more than once, leading to ambiguous alignment.
+//        for (element in collection) {
+//            $calleeName(...) // Broken
+//        }
+//        for (element in collection) {
+//            alignedOn(element) { // Manual alignment on element, assuming it is unique
+//                $calleeName(...)
+//            }
+//        }
+//        """.trimIndent()
 
     /**
      * Getter for all Collection members using Kotlin reflection, obtaining their names as a set.
@@ -117,11 +117,7 @@ object NoAlignInsideLoop : FirFunctionCallChecker(MppCheckerKind.Common) {
     private fun CheckerContext.isIteratedWithoutAlignedOn(): Boolean =
         isInsideALoopWithoutAlignedOn() || isInsideIteratedFunctionWithoutAlignedOn()
 
-    override fun check(
-        expression: FirFunctionCall,
-        context: CheckerContext,
-        reporter: DiagnosticReporter,
-    ) {
+    override fun check(expression: FirFunctionCall, context: CheckerContext, reporter: DiagnosticReporter) {
         val calleeName = expression.functionName()
         if (expression.fqName() !in safeOperators &&
             expression.isAggregate(context.session) &&
@@ -129,8 +125,8 @@ object NoAlignInsideLoop : FirFunctionCallChecker(MppCheckerKind.Common) {
         ) {
             reporter.reportOn(
                 expression.calleeReference.source,
-                CheckersUtility.PluginErrors.DOT_CALL_WARNING,
-                createWarning(calleeName),
+                FirCollektiveErrors.AGGREGATE_FUNCTION_INSIDE_ITERATION,
+                calleeName,
                 context,
             )
         }

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/NoAlignInsideLoop.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/NoAlignInsideLoop.kt
@@ -7,6 +7,7 @@ import it.unibo.collektive.frontend.checkers.CheckersUtility.functionName
 import it.unibo.collektive.frontend.checkers.CheckersUtility.isAggregate
 import it.unibo.collektive.frontend.checkers.CheckersUtility.isFunctionCallsWithName
 import it.unibo.collektive.frontend.checkers.CheckersUtility.wrappingElementsUntil
+import it.unibo.collektive.utils.common.AggregateFunctionNames
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
@@ -24,27 +25,27 @@ import kotlin.reflect.jvm.kotlinFunction
 object NoAlignInsideLoop : FirFunctionCallChecker(MppCheckerKind.Common) {
 
     private val safeOperators = listOf(
-        "it.unibo.collektive.aggregate.api.Aggregate.alignedOn",
-        "it.unibo.collektive.aggregate.api.Aggregate.align",
-        "it.unibo.collektive.aggregate.api.Aggregate.dealign",
+        AggregateFunctionNames.ALIGNED_ON_FUNCTION_FQ_NAME,
+        AggregateFunctionNames.ALIGN_FUNCTION_FQ_NAME,
+        AggregateFunctionNames.DEALIGN_FUNCTION_FQ_NAME,
     )
 
-//    /**
-//     * Creates a warning for this checker, formatted with the [calleeName] that originated it.
-//     */
-//    fun createWarning(calleeName: String): String =
-//        """
-//        Warning: aggregate function '$calleeName' has been called inside a loop construct without explicit alignment.
-//        The same path may generate interactions more than once, leading to ambiguous alignment.
-//        for (element in collection) {
-//            $calleeName(...) // Broken
-//        }
-//        for (element in collection) {
-//            alignedOn(element) { // Manual alignment on element, assuming it is unique
-//                $calleeName(...)
-//            }
-//        }
-//        """.trimIndent()
+    //    /**
+    //     * Creates a warning for this checker, formatted with the [calleeName] that originated it.
+    //     */
+    //    fun createWarning(calleeName: String): String =
+    //        """
+    //        Warning: aggregate function '$calleeName' has been called inside a loop construct without explicit alignment.
+    //        The same path may generate interactions more than once, leading to ambiguous alignment.
+    //        for (element in collection) {
+    //            $calleeName(...) // Broken
+    //        }
+    //        for (element in collection) {
+    //            alignedOn(element) { // Manual alignment on element, assuming it is unique
+    //                $calleeName(...)
+    //            }
+    //        }
+    //        """.trimIndent()
 
     /**
      * Getter for all Collection members using Kotlin reflection, obtaining their names as a set.
@@ -106,13 +107,13 @@ object NoAlignInsideLoop : FirFunctionCallChecker(MppCheckerKind.Common) {
         wrappingElementsUntil { it is FirWhileLoop }
             ?.discardIfFunctionDeclaration()
             ?.discardIfOutsideAggregateEntryPoint()
-            ?.none(isFunctionCallsWithName("alignedOn")) ?: false
+            ?.none(isFunctionCallsWithName(AggregateFunctionNames.ALIGNED_ON_FUNCTION_NAME)) ?: false
 
     private fun CheckerContext.isInsideIteratedFunctionWithoutAlignedOn(): Boolean =
         wrappingElementsUntil { it is FirFunctionCall && it.functionName() in collectionMembers }
             ?.discardIfFunctionDeclaration()
             ?.discardIfOutsideAggregateEntryPoint()
-            ?.none(isFunctionCallsWithName("alignedOn")) ?: false
+            ?.none(isFunctionCallsWithName(AggregateFunctionNames.ALIGNED_ON_FUNCTION_NAME)) ?: false
 
     private fun CheckerContext.isIteratedWithoutAlignedOn(): Boolean =
         isInsideALoopWithoutAlignedOn() || isInsideIteratedFunctionWithoutAlignedOn()

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/NoAlignInsideLoop.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/frontend/checkers/NoAlignInsideLoop.kt
@@ -30,23 +30,6 @@ object NoAlignInsideLoop : FirFunctionCallChecker(MppCheckerKind.Common) {
         AggregateFunctionNames.DEALIGN_FUNCTION_FQ_NAME,
     )
 
-    //    /**
-    //     * Creates a warning for this checker, formatted with the [calleeName] that originated it.
-    //     */
-    //    fun createWarning(calleeName: String): String =
-    //        """
-    //        Warning: aggregate function '$calleeName' has been called inside a loop construct without explicit alignment.
-    //        The same path may generate interactions more than once, leading to ambiguous alignment.
-    //        for (element in collection) {
-    //            $calleeName(...) // Broken
-    //        }
-    //        for (element in collection) {
-    //            alignedOn(element) { // Manual alignment on element, assuming it is unique
-    //                $calleeName(...)
-    //            }
-    //        }
-    //        """.trimIndent()
-
     /**
      * Getter for all Collection members using Kotlin reflection, obtaining their names as a set.
      */

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/transformers/AlignmentTransformer.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/transformers/AlignmentTransformer.kt
@@ -1,7 +1,7 @@
 package it.unibo.collektive.transformers
 
-import it.unibo.collektive.utils.common.AggregateFunctionNames.ALIGN_FUNCTION
-import it.unibo.collektive.utils.common.AggregateFunctionNames.DEALIGN_RAW_FUNCTION
+import it.unibo.collektive.utils.common.AggregateFunctionNames.ALIGN_FUNCTION_NAME
+import it.unibo.collektive.utils.common.AggregateFunctionNames.DEALIGN_FUNCTION_NAME
 import it.unibo.collektive.utils.common.findAggregateReference
 import it.unibo.collektive.utils.common.getAlignmentToken
 import it.unibo.collektive.utils.common.irStatement
@@ -60,7 +60,7 @@ class AlignmentTransformer(
         return contextReference?.let { context ->
             // We don't want to align the alignRaw and dealign functions :)
             val functionName = expression.simpleFunctionName()
-            if (functionName == ALIGN_FUNCTION || functionName == DEALIGN_RAW_FUNCTION) {
+            if (functionName == ALIGN_FUNCTION_NAME || functionName == DEALIGN_FUNCTION_NAME) {
                 return super.visitCall(expression, data)
             }
             // If no function, the first time the counter is 1

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/transformers/FieldTransformer.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/transformers/FieldTransformer.kt
@@ -34,8 +34,8 @@ class FieldTransformer(
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     override fun visitCall(expression: IrCall): IrExpression {
         val symbolName = expression.symbol.owner.name
-        val alignRawIdentifier = Name.identifier(AggregateFunctionNames.ALIGN_FUNCTION)
-        val alignedOnIdentifier = Name.identifier(AggregateFunctionNames.ALIGNED_ON_FUNCTION)
+        val alignRawIdentifier = Name.identifier(AggregateFunctionNames.ALIGN_FUNCTION_NAME)
+        val alignedOnIdentifier = Name.identifier(AggregateFunctionNames.ALIGNED_ON_FUNCTION_NAME)
         if (symbolName == alignRawIdentifier || symbolName == alignedOnIdentifier) {
             logger.debug("Found alignedRaw function call: ${expression.dumpKotlinLike()}")
             val contextReference = expression.receiverAndArgs()

--- a/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/common/AggregateFunctionNames.kt
+++ b/compiler-plugin/src/main/kotlin/it/unibo/collektive/utils/common/AggregateFunctionNames.kt
@@ -5,24 +5,44 @@ package it.unibo.collektive.utils.common
  */
 object AggregateFunctionNames {
     /**
-     * The name of the function that is used to align.
+     * The simple name of the function that is used to align a block.
      */
-    const val ALIGNED_ON_FUNCTION = "alignedOn"
+    const val ALIGNED_ON_FUNCTION_NAME = "alignedOn"
 
     /**
-     * The name of the function that is used to align.
+     * The FQ name of the function that is used to align a block.
      */
-    const val ALIGN_FUNCTION = "align"
+    const val ALIGNED_ON_FUNCTION_FQ_NAME = "it.unibo.collektive.aggregate.api.Aggregate.alignedOn"
 
     /**
-     * The name of the function that is used to de-align.
+     * The simple name of the function that is used to start an alignment delimitation.
      */
-    const val DEALIGN_RAW_FUNCTION = "dealign"
+    const val ALIGN_FUNCTION_NAME = "align"
+
+    /**
+     * The FQ name of the function that is used to start an alignment delimitation.
+     */
+    const val ALIGN_FUNCTION_FQ_NAME = "it.unibo.collektive.aggregate.api.Aggregate.align"
+
+    /**
+     * The name of the function that is used to stop an alignment delimitation.
+     */
+    const val DEALIGN_FUNCTION_NAME = "dealign"
+
+    /**
+     * The FQ name of the function that is used to stop an alignment delimitation.
+     */
+    const val DEALIGN_FUNCTION_FQ_NAME = "it.unibo.collektive.aggregate.api.Aggregate.dealign"
+
+    /**
+     * The simple name of the aggregate class.
+     */
+    const val AGGREGATE_CLASS_NAME = "Aggregate"
 
     /**
      * The FQ name of the aggregate class.
      */
-    const val AGGREGATE_CLASS = "it.unibo.collektive.aggregate.api.Aggregate"
+    const val AGGREGATE_CLASS_FQ_NAME = "it.unibo.collektive.aggregate.api.Aggregate"
 
     /**
      * The FQ name of the field class.
@@ -33,9 +53,4 @@ object AggregateFunctionNames {
      * The name of the function that is used to project the fields.
      */
     const val PROJECT_FUNCTION = "project"
-
-    /**
-     * The name of the function showing if the compiler plugin is applied.
-     */
-    const val IS_COMPILER_PLUGIN_APPLIED_FUNCTION = "isCompilerPluginApplied"
 }


### PR DESCRIPTION
This PR tries to follow the convention for error generation followed by jetbrains in their compiler plugins:

[Kotlinx.serialization errors definitions](https://github.com/JetBrains/kotlin/blob/master/plugins/kotlinx-serialization/kotlinx-serialization.k2/src/org/jetbrains/kotlinx/serialization/compiler/fir/checkers/FirSerializationErrors.kt)
[Kotlinx.serialization rendering factory](https://github.com/JetBrains/kotlin/blob/master/plugins/kotlinx-serialization/kotlinx-serialization.k2/src/org/jetbrains/kotlinx/serialization/compiler/fir/checkers/KtDefaultErrorMessagesSerialization.kt)

## Update

Apparently, this PR closes #507 but the warning inside the IDE is not raised because of the following issue:
[IDEA-363292](https://youtrack.jetbrains.com/issue/IDEA-363292)

To reproduce the error inside the IDE follow the steps:
  - Enable K2 mode inside the IDE `Settings -> Language & Frameworks -> Kotlin`
  - Enter in the menu with `shift + shift` digit **Registry**, then identify the `kotlin.k2.only.bundled.compiler.plugins.enabled` entry and **UNSET** the flag
  - Rebuild the compiler plugin
  - Reload the build inside the IDE

@FreshMag could you try to reproduce this error?