### PR TITLE
test: changed DSL test using the implicit parameter of 'share' block

### DIFF
--- a/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/AlignmentTest.kt
+++ b/dsl/src/commonTest/kotlin/it/unibo/collektive/alignment/AlignmentTest.kt
@@ -21,9 +21,9 @@ class AlignmentTest : StringSpec({
         val result =
             aggregate(0) {
                 neighboringViaExchange(10) // path -> [neighboring.1] = 10
-                share(0) {
+                share(5) {
                     requireNotNull(neighboringViaExchange(20).localValue) // path -> [share.1, neighboring.2] = 20
-                    5
+                    it.localValue
                 } // path -> [sharing.1] = 5
                 neighboringViaExchange(30) // path -> [neighboring.3] = 30
                 5


### PR DESCRIPTION
Refactoring of `AlignmentTest`, changing hard-coded return of `5` with `it.localValue`, using the implicit parameter of the `share` block.

This is done to prevent this test from raising a warning when using the checker implemented in #668 