### PR TITLE
fix(dsl): manually align field mapping operations to allow aggregate functions execution in mappings. Fixes #960

### DIFF
--- a/collektive-dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/Field.kt
+++ b/collektive-dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/Field.kt
@@ -610,6 +610,7 @@ internal class ConstantField<ID : Any, T>(
             context.alignedOn(it) {
                 FieldEntry(checkNotLocal(it), local.value).map(transform)
             }
+        }
 
     override fun neighborValueOf(id: ID): T = local.value
 

--- a/collektive-dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/Field.kt
+++ b/collektive-dsl/src/commonMain/kotlin/it/unibo/collektive/aggregate/Field.kt
@@ -606,10 +606,10 @@ internal class ConstantField<ID : Any, T>(
 
     override fun <R> mapOthersAsSequence(transform: (FieldEntry<ID, T>) -> R): Sequence<FieldEntry<ID, R>> =
         neighbors.asSequence().map {
+            // `it` here represents an ID of a neighboring node, as expected by `context.alignedOn`.
             context.alignedOn(it) {
                 FieldEntry(checkNotLocal(it), local.value).map(transform)
             }
-        }
 
     override fun neighborValueOf(id: ID): T = local.value
 

--- a/collektive-dsl/src/jvmTest/kotlin/it/unibo/collektive/aggregate/FieldOpsTest.kt
+++ b/collektive-dsl/src/jvmTest/kotlin/it/unibo/collektive/aggregate/FieldOpsTest.kt
@@ -6,10 +6,16 @@
  * as described in the LICENSE file in this project's repository's top directory.
  */
 
+@file:CollektiveIgnore("This test needs to mock the context and does not use projection nor alignment")
+
 package it.unibo.collektive.aggregate
 
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import it.unibo.collektive.aggregate.api.Aggregate
+import it.unibo.collektive.aggregate.api.CollektiveIgnore
 import it.unibo.collektive.stdlib.fields.fold
 import it.unibo.collektive.stdlib.fields.foldValues
 import it.unibo.collektive.stdlib.fields.reduce
@@ -20,7 +26,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 class FieldOpsTest {
-    private val mockedContext = mockk<Aggregate<Int>>(relaxed = true)
+    private val mockedContext = mockk<Aggregate<Int>>().apply {
+        every { align(anyNullable()) } just Runs
+        every { dealign() } just Runs
+        every { alignedOn(anyNullable(), captureLambda<() -> Any?>()) } answers {
+            lambda<() -> Any?>().captured.invoke()
+        }
+    }
     private val emptyField = Field(mockedContext, 0, "localVal")
     private val field = Field(mockedContext, 0, 0, mapOf(1 to 10, 2 to 20))
     private val fulfilledField = Field(mockedContext, 0, 0, mapOf(1 to 10, 2 to 20, 3 to 15))


### PR DESCRIPTION
Closes #960 