### PR TITLE
fix(dsl): support Kotlin's `Uuid` as device `ID`

### DIFF
--- a/collektive-dsl/src/commonMain/kotlin/it/unibo/collektive/path/DigestHashingFactory.kt
+++ b/collektive-dsl/src/commonMain/kotlin/it/unibo/collektive/path/DigestHashingFactory.kt
@@ -12,6 +12,8 @@ import org.kotlincrypto.hash.sha3.Keccak512
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmInline
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * A factory that creates [Path] instances by hashing their content.
@@ -87,6 +89,7 @@ value class DigestHashingFactory(val digest: Digest = KotlinCryptoDigest(Keccak5
         }
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     private fun Any.toConvertedByteArray(): ByteArray = when (this) {
         is UByte -> this.toByte().toByteArray()
         is Short -> this.toInt().toByteArray()
@@ -96,6 +99,7 @@ value class DigestHashingFactory(val digest: Digest = KotlinCryptoDigest(Keccak5
         is Float -> this.toRawBits().toByteArray()
         is Double -> this.toRawBits().toByteArray()
         is Char -> this.toString().toByteArray()
+        is Uuid -> this.toString().encodeToByteArray()
         else -> error("Alignment on elements of type ${this::class.simpleName} is not supported")
     }
 

--- a/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
+++ b/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
@@ -20,7 +20,7 @@ import kotlin.uuid.Uuid
 class DigestHashingFactoryTest {
     @OptIn(ExperimentalUuidApi::class)
     @Test
-    fun `multiGradientCast with Uuid test set cast to alignedOn`() {
+    fun `Uuids must be valid device identifiers`() {
         val sources: Set<Uuid> = setOf(
             Uuid.parse("00000000-0000-0000-0000-000000000001"),
             Uuid.parse("00000000-0000-0000-0000-000000000002"),

--- a/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
+++ b/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
@@ -30,7 +30,7 @@ class DigestHashingFactoryTest {
             multiGradientCast(
                 sources = sources,
                 local = "data",
-                metric = { neighboring(1.0) },
+                metric = neighboring(1.0),
             )
         }
         assertEquals(3, result.result.size)

--- a/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
+++ b/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, Danilo Pianini, Nicolas Farabegoli, Elisa Tronetti,
+ * and all authors listed in the `build.gradle.kts` and the generated `pom.xml` file.
+ *
+ * This file is part of Collektive, and is distributed under the terms of the Apache License 2.0,
+ * as described in the LICENSE file in this project's repository's top directory.
+ */
+
+package it.unibo.collektive.path
+
+import it.unibo.collektive.Collektive
+import it.unibo.collektive.aggregate.api.Aggregate
+import it.unibo.collektive.aggregate.api.neighboring
+import it.unibo.collektive.stdlib.spreading.multiGradientCast
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class DigestHashingFactoryTest {
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `multiGradientCast with Uuid test set cast to alignedOn`() {
+        val sources: Set<Uuid> = setOf(
+            Uuid.parse("00000000-0000-0000-0000-000000000001"),
+            Uuid.parse("00000000-0000-0000-0000-000000000002"),
+            Uuid.parse("00000000-0000-0000-0000-000000000003")
+        )
+
+        fun metric(agg: Aggregate<Uuid>) = agg.neighboring(1.0)
+
+        fun run(agg: Aggregate<Uuid>) = agg.multiGradientCast(
+            sources = sources,
+            local = "data",
+            metric = metric(agg)
+        )
+
+        val result = Collektive.Companion.aggregate(sources.first()) {
+            run(this)
+        }
+
+        assertEquals(3, result.result.size)
+        assertEquals(sources, result.result.keys)
+    }
+}

--- a/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
+++ b/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
@@ -27,16 +27,16 @@ class DigestHashingFactoryTest {
             Uuid.parse("00000000-0000-0000-0000-000000000003"),
         )
 
-        fun metric(agg: Aggregate<Uuid>) = agg.neighboring(1.0)
+        fun Aggregate<Uuid>.metric() = neighboring(1.0)
 
-        fun run(agg: Aggregate<Uuid>) = agg.multiGradientCast(
+        fun Aggregate<Uuid>.run() = multiGradientCast(
             sources = sources,
             local = "data",
-            metric = metric(agg),
+            metric = metric(),
         )
 
-        val result = Collektive.Companion.aggregate(sources.first()) {
-            run(this)
+        val result = Collektive.aggregate(sources.first()) {
+            run()
         }
 
         assertEquals(3, result.result.size)

--- a/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
+++ b/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
@@ -26,19 +26,13 @@ class DigestHashingFactoryTest {
             Uuid.parse("00000000-0000-0000-0000-000000000002"),
             Uuid.parse("00000000-0000-0000-0000-000000000003"),
         )
-
-        fun Aggregate<Uuid>.metric() = neighboring(1.0)
-
-        fun Aggregate<Uuid>.run() = multiGradientCast(
-            sources = sources,
-            local = "data",
-            metric = metric(),
-        )
-
         val result = Collektive.aggregate(sources.first()) {
-            run()
+            multiGradientCast(
+                sources = sources,
+                local = "data",
+                metric = { neighboring(1.0) },
+            )
         }
-
         assertEquals(3, result.result.size)
         assertEquals(sources, result.result.keys)
     }

--- a/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
+++ b/collektive-dsl/src/commonTest/kotlin/it/unibo/collektive/path/DigestHashingFactoryTest.kt
@@ -24,7 +24,7 @@ class DigestHashingFactoryTest {
         val sources: Set<Uuid> = setOf(
             Uuid.parse("00000000-0000-0000-0000-000000000001"),
             Uuid.parse("00000000-0000-0000-0000-000000000002"),
-            Uuid.parse("00000000-0000-0000-0000-000000000003")
+            Uuid.parse("00000000-0000-0000-0000-000000000003"),
         )
 
         fun metric(agg: Aggregate<Uuid>) = agg.neighboring(1.0)
@@ -32,7 +32,7 @@ class DigestHashingFactoryTest {
         fun run(agg: Aggregate<Uuid>) = agg.multiGradientCast(
             sources = sources,
             local = "data",
-            metric = metric(agg)
+            metric = metric(agg),
         )
 
         val result = Collektive.Companion.aggregate(sources.first()) {


### PR DESCRIPTION
Added explicit support for kotlin.uuid.Uuid in DigestHashingFactory to enable alignment on UUID-based paths. The Uuid type is now converted to a ByteArray via its string representation.

Fixes IllegalStateException: "Alignment on elements of type Uuid is not supported" when using alignedOn(...) with UUIDs in aggregate programs.